### PR TITLE
feat: inline attachment tray for pasted captures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## [Unreleased]
+### Added
+- Enable AI weather insight panel with screenshot uploads analysed through the OpenAI gateway.
+- Support clipboard paste and drag-and-drop ingestion for ADNOC weather screenshots so control tower operators can analyse live captures without saving files manually.
+- Provide in-app API gateway configuration with persistent storage to target custom OpenAI deployment ports.
+- Mirror clipboard attachments in a persistent inline tray so pasted captures stay visible outside the assistant modal.
+
+### Fixed
+- Handle missing `OPENAI_API_KEY` gracefully by loading `.env` configuration and surfacing
+  configuration errors directly from the OpenAI gateway endpoints.
+- Surface detailed OpenAI gateway errors in the UI when assistant or briefing calls fail instead of returning opaque 502 messages.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - Separate sail vs discharge weather limits with inline readiness badges and voyage mini-Gantt bars.
 - Add MW4 waiting strategy toggle so vessels hold departure until both sail and discharge windows are safe.
 - Cover gateway workflows with automated pytest suite to ensure OpenAI connectivity remains green.
+- Normalize free-form schedule text or screenshots via `/api/schedule/normalize`, estimating ETD/ETA when only Voyage/Cargo are provided.
+- Accept text files and pasted captures in the schedule uploader with hover-to-paste detection and AI fallback, while keeping the vessel info panel scrollable on smaller viewports.
 
 ### Fixed
 - Handle missing `OPENAI_API_KEY` gracefully by loading `.env` configuration and surfacing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Support clipboard paste and drag-and-drop ingestion for ADNOC weather screenshots so control tower operators can analyse live captures without saving files manually.
 - Provide in-app API gateway configuration with persistent storage to target custom OpenAI deployment ports.
 - Mirror clipboard attachments in a persistent inline tray so pasted captures stay visible outside the assistant modal.
+- Separate sail vs discharge weather limits with inline readiness badges and voyage mini-Gantt bars.
+- Add MW4 waiting strategy toggle so vessels hold departure until both sail and discharge windows are safe.
+- Cover gateway workflows with automated pytest suite to ensure OpenAI connectivity remains green.
 
 ### Fixed
 - Handle missing `OPENAI_API_KEY` gracefully by loading `.env` configuration and surfacing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Added
+- Auto-detect headerless voyage CSV exports so MW4 schedule dumps upload without manual editing.
 - Enable AI weather insight panel with screenshot uploads analysed through the OpenAI gateway.
 - Support clipboard paste and drag-and-drop ingestion for ADNOC weather screenshots so control tower operators can analyse live captures without saving files manually.
 - Provide in-app API gateway configuration with persistent storage to target custom OpenAI deployment ports.
@@ -14,3 +15,4 @@
 - Handle missing `OPENAI_API_KEY` gracefully by loading `.env` configuration and surfacing
   configuration errors directly from the OpenAI gateway endpoints.
 - Surface detailed OpenAI gateway errors in the UI when assistant or briefing calls fail instead of returning opaque 502 messages.
+- Align OpenAI Responses payloads with `input_text` / `output_text` blocks to eliminate invalid value errors during assistant calls.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ A comprehensive maritime logistics control system with real-time vessel tracking
 
 ### 🌤️ Weather Integration
 - Marine weather data from Open-Meteo API
+- ADNOC weather screenshots interpreted by AI for rapid risk flagging
+- Clipboard paste and drag-and-drop ingestion for screenshot uploads
+- Inline attachment tray mirrors pasted captures for quick review
 - IOI (Index of Operability) calculation (0-100 scale)
 - Go/No-Go decision support based on weather conditions
 - Real-time marine snapshot display (wave height, wind speed)
@@ -20,6 +23,8 @@ A comprehensive maritime logistics control system with real-time vessel tracking
 - AI assistant for logistics questions
 - Risk analysis and mitigation recommendations
 - File upload support (PDF, images, CSV)
+- Dedicated AI weather insight panel for screenshot uploads
+- Unified attachment preview in both control panel and assistant modal
 
 ### 📊 Schedule Management
 - Voyage schedule management with CSV/JSON import
@@ -56,8 +61,10 @@ cd WEATHER-VESSEL
 pip install -r requirements.txt
 ```
 
-3. Set up environment variables:
+3. Set up environment variables (supports `.env` file in project root):
 ```bash
+echo "OPENAI_API_KEY=your-openai-api-key" >> .env
+# or export directly for the current shell
 export OPENAI_API_KEY="your-openai-api-key"
 ```
 
@@ -67,13 +74,15 @@ python -m uvicorn openai_gateway:app --host 0.0.0.0 --port 8000 --reload
 ```
 
 5. Open `logistics_control_tower_v2.html` in your browser
+6. If your gateway is running on a different host/port, click the **API 설정** button in the Vessel Control panel to update the base URL (right-click to reset to the default)
 
 ## Usage
 
 ### Basic Operations
 - **Vessel Tracking**: View real-time vessel position and route
 - **Schedule Upload**: Import voyage schedules via CSV/JSON
-- **Weather Data**: Upload weather data for risk analysis
+- **Weather Data**: Upload weather data (CSV) or ADNOC screenshots for risk analysis
+- **Weather Screenshots**: Paste from clipboard or drag-and-drop captures directly into the weather uploader
 - **AI Assistant**: Ask questions about logistics operations
 - **Daily Briefing**: Generate AI-powered operational summaries
 
@@ -82,6 +91,11 @@ python -m uvicorn openai_gateway:app --host 0.0.0.0 --port 8000 --reload
 - **Risk Simulation**: Test different scenarios
 - **Weather Linking**: Automatic schedule adjustments based on weather
 - **File Analysis**: Upload documents for AI analysis
+
+### API Gateway Configuration
+- Click **API 설정** (Vessel Control panel) to set the OpenAI gateway base URL; the value persists in local storage.
+- Right-click the same button to revert to the default gateway defined in the HTML `data-api-base-url` attribute.
+- The API status chip displays live connectivity and target host/port after each health check.
 
 ## API Endpoints
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A comprehensive maritime logistics control system with real-time vessel tracking
 - Inline attachment tray mirrors pasted captures for quick review
 - IOI (Index of Operability) calculation (0-100 scale)
 - Go/No-Go decision support based on weather conditions
+- Separate sail vs discharge thresholds for Sea State and wind/visibility decisions
 - Real-time marine snapshot display (wave height, wind speed)
 
 ### 🤖 AI-Powered Features
@@ -29,6 +30,7 @@ A comprehensive maritime logistics control system with real-time vessel tracking
 ### 📊 Schedule Management
 - Voyage schedule management with CSV/JSON import
 - Weather-linked schedule adjustments
+- Sail/Discharge readiness badges with per-leg mini-Gantt timeline
 - Risk simulation and control
 - Live status updates
 
@@ -70,7 +72,7 @@ export OPENAI_API_KEY="your-openai-api-key"
 
 4. Start the FastAPI server:
 ```bash
-python -m uvicorn openai_gateway:app --host 0.0.0.0 --port 8000 --reload
+python -m uvicorn openai_gateway:app --host 0.0.0.0 --port 8002 --reload
 ```
 
 5. Open `logistics_control_tower_v2.html` in your browser
@@ -85,6 +87,7 @@ python -m uvicorn openai_gateway:app --host 0.0.0.0 --port 8000 --reload
 - **Weather Screenshots**: Paste from clipboard or drag-and-drop captures directly into the weather uploader
 - **AI Assistant**: Ask questions about logistics operations
 - **Daily Briefing**: Generate AI-powered operational summaries
+- **AGI 대기 금지 토글**: 출항 지연 전략 스위치를 켜서 하역 가능 시점까지 MW4에서 대기하도록 자동 조정
 
 ### Advanced Features
 - **IOI Analysis**: Automatic operability assessment

--- a/README.md
+++ b/README.md
@@ -1,0 +1,124 @@
+# Weather Vessel - Logistics Control Tower v2.5
+
+A comprehensive maritime logistics control system with real-time vessel tracking, weather integration, and AI-powered decision support.
+
+## Features
+
+### 🗺️ Real-time Vessel Tracking
+- Interactive Leaflet map with vessel route visualization
+- Real-time position updates and progress tracking
+- Route optimization and ETA calculations
+
+### 🌤️ Weather Integration
+- Marine weather data from Open-Meteo API
+- IOI (Index of Operability) calculation (0-100 scale)
+- Go/No-Go decision support based on weather conditions
+- Real-time marine snapshot display (wave height, wind speed)
+
+### 🤖 AI-Powered Features
+- Daily logistics briefing generation
+- AI assistant for logistics questions
+- Risk analysis and mitigation recommendations
+- File upload support (PDF, images, CSV)
+
+### 📊 Schedule Management
+- Voyage schedule management with CSV/JSON import
+- Weather-linked schedule adjustments
+- Risk simulation and control
+- Live status updates
+
+### ♿ Accessibility (WCAG 2.2 AA)
+- Keyboard navigation support
+- Screen reader compatibility
+- High contrast mode support
+- 44px minimum touch targets
+- Skip links and ARIA attributes
+
+## Technology Stack
+
+- **Frontend**: HTML5, CSS3, JavaScript (ES6+)
+- **Styling**: Tailwind CSS
+- **Maps**: Leaflet.js 1.9.4
+- **Backend**: FastAPI (Python)
+- **AI Integration**: OpenAI API
+- **Performance**: Web Workers, requestIdleCallback
+
+## Installation
+
+1. Clone the repository:
+```bash
+git clone https://github.com/macho715/WEATHER-VESSEL.git
+cd WEATHER-VESSEL
+```
+
+2. Install Python dependencies:
+```bash
+pip install -r requirements.txt
+```
+
+3. Set up environment variables:
+```bash
+export OPENAI_API_KEY="your-openai-api-key"
+```
+
+4. Start the FastAPI server:
+```bash
+python -m uvicorn openai_gateway:app --host 0.0.0.0 --port 8000 --reload
+```
+
+5. Open `logistics_control_tower_v2.html` in your browser
+
+## Usage
+
+### Basic Operations
+- **Vessel Tracking**: View real-time vessel position and route
+- **Schedule Upload**: Import voyage schedules via CSV/JSON
+- **Weather Data**: Upload weather data for risk analysis
+- **AI Assistant**: Ask questions about logistics operations
+- **Daily Briefing**: Generate AI-powered operational summaries
+
+### Advanced Features
+- **IOI Analysis**: Automatic operability assessment
+- **Risk Simulation**: Test different scenarios
+- **Weather Linking**: Automatic schedule adjustments based on weather
+- **File Analysis**: Upload documents for AI analysis
+
+## API Endpoints
+
+- `GET /health` - Health check
+- `POST /api/assistant` - AI assistant chat
+- `POST /api/briefing` - Generate daily briefing
+
+## Performance Optimizations
+
+- **Web Workers**: Marine data fetching in background threads
+- **Idle Callbacks**: Non-blocking UI updates
+- **Passive Event Listeners**: Optimized scroll/touch handling
+- **Lazy Loading**: Efficient resource management
+
+## Accessibility Features
+
+- **Keyboard Navigation**: Full keyboard support
+- **Screen Reader**: ARIA labels and roles
+- **High Contrast**: System preference detection
+- **Touch Targets**: 44px minimum size compliance
+- **Focus Management**: Proper focus handling in modals
+
+## Contributing
+
+1. Fork the repository
+2. Create a feature branch
+3. Make your changes
+4. Test thoroughly
+5. Submit a pull request
+
+## License
+
+This project is licensed under the MIT License - see the LICENSE file for details.
+
+## Acknowledgments
+
+- Open-Meteo for marine weather data
+- Leaflet for mapping functionality
+- OpenAI for AI capabilities
+- Tailwind CSS for styling framework

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ A comprehensive maritime logistics control system with real-time vessel tracking
 
 ### 📊 Schedule Management
 - Voyage schedule management with CSV/JSON import
+- Free-form text or screenshot ingestion with AI-powered normalization (Voyage & Cargo only required)
 - Weather-linked schedule adjustments
 - Sail/Discharge readiness badges with per-leg mini-Gantt timeline
 - Risk simulation and control
@@ -82,7 +83,7 @@ python -m uvicorn openai_gateway:app --host 0.0.0.0 --port 8002 --reload
 
 ### Basic Operations
 - **Vessel Tracking**: View real-time vessel position and route
-- **Schedule Upload**: Import voyage schedules via CSV/JSON
+- **Schedule Upload**: Import voyage schedules via CSV/JSON, plain text, or screenshots (Voyage/Cargo만 있어도 자동 시간 보완)
 - **Weather Data**: Upload weather data (CSV) or ADNOC screenshots for risk analysis
 - **Weather Screenshots**: Paste from clipboard or drag-and-drop captures directly into the weather uploader
 - **AI Assistant**: Ask questions about logistics operations
@@ -105,6 +106,7 @@ python -m uvicorn openai_gateway:app --host 0.0.0.0 --port 8002 --reload
 - `GET /health` - Health check
 - `POST /api/assistant` - AI assistant chat
 - `POST /api/briefing` - Generate daily briefing
+- `POST /api/schedule/normalize` - Normalize free-form schedule text or images into structured voyages
 
 ## Performance Optimizations
 

--- a/logistics_control_tower_v2.html
+++ b/logistics_control_tower_v2.html
@@ -79,8 +79,8 @@
 
         <div class="mt-4 grid grid-cols-2 gap-2">
           <label class="w-full">
-            <input type="file" id="file-schedule" class="hidden" accept=".csv,.json"/>
-            <span id="label-schedule" class="w-full inline-flex items-center justify-center bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-3 rounded-lg cursor-pointer">Upload Schedule (CSV/JSON)</span>
+            <input type="file" id="file-schedule" class="hidden" accept=".csv,.json,.txt,image/*"/>
+            <span id="label-schedule" class="w-full inline-flex items-center justify-center bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-3 rounded-lg cursor-pointer drop-zone">Upload Schedule (CSV/TXT/Image)</span>
           </label>
           <label class="w-full">
             <input type="file" id="file-weather" class="hidden" accept=".csv,image/*"/>
@@ -89,6 +89,7 @@
         </div>
         <div class="mt-3 space-y-2 text-xs text-slate-400">
           <p>Tips: Press <span class="kbd">Esc</span> to close modals. 파일 포맷은 하단 가이드를 참고.</p>
+          <p class="text-slate-300">스케줄은 CSV/텍스트/스크린샷 모두 지원하며 Voyage·Cargo만 있어도 자동 완성됩니다.</p>
           <div class="flex items-center justify-between gap-2">
             <div>API 상태 <span class="chip" id="api-status">API: Offline</span></div>
             <button id="api-config-btn" class="px-2 py-1 rounded bg-slate-800/70 hover:bg-slate-700 text-slate-100 border border-slate-600 text-[11px] font-semibold">API 설정</button>
@@ -716,12 +717,175 @@
     const weatherInput  = document.getElementById('file-weather');
     const scheduleLabel = document.getElementById('label-schedule');
     const weatherLabel  = document.getElementById('label-weather');
+    const scheduleDropTarget = scheduleLabel?.parentElement || scheduleLabel;
     const weatherDropTarget = weatherLabel?.parentElement || weatherLabel;
     const weatherBusyClasses = ['bg-amber-500','hover:bg-amber-500','animate-pulse'];
     const weatherReadyClasses = ['bg-emerald-600','hover:bg-emerald-700'];
 
-    scheduleLabel.addEventListener('click',()=> scheduleInput.click());
-    weatherLabel.addEventListener('click',()=> weatherInput.click());
+    scheduleLabel?.addEventListener('click',()=> scheduleInput?.click());
+    weatherLabel?.addEventListener('click',()=> weatherInput?.click());
+
+    function canonicalizeScheduleRows(rows){
+      if(!Array.isArray(rows)) throw new Error('Schedule payload must be an array');
+      return rows.map((raw, idx)=>{
+        const record = Array.isArray(raw) ? {
+          id: raw[0], cargo: raw[1], etd: raw[2], eta: raw[3], status: raw[4]
+        } : raw || {};
+        const id = record.id ?? record.voyage ?? record.Voyage ?? record.trip ?? record.Voy ?? record.VOYAGE ?? '';
+        const cargo = record.cargo ?? record.Cargo ?? record.commodity ?? record.load ?? '';
+        const etd = record.etd ?? record.ETD ?? record.departure ?? record.depart ?? record.load_time ?? '';
+        const eta = record.eta ?? record.ETA ?? record.arrival ?? record.disch ?? record.discharge_time ?? '';
+        const status = record.status ?? record.Status ?? 'Scheduled';
+        const etdDt = parseISO(etd);
+        const etaDt = parseISO(eta);
+        if(!String(id).trim() || !String(cargo).trim() || !etdDt || !etaDt){
+          throw new Error(`Missing required fields (id,cargo,etd,eta) at row ${idx+1}`);
+        }
+        return {
+          id: String(id).trim(),
+          cargo: String(cargo).trim(),
+          etd: fmtIso(etdDt),
+          eta: fmtIso(etaDt),
+          status: String(status || 'Scheduled').trim() || 'Scheduled'
+        };
+      });
+    }
+
+    function applyScheduleData(rows, meta = {}){
+      if(!Array.isArray(rows) || !rows.length){
+        throw new Error('No schedule rows provided');
+      }
+      const normalized = canonicalizeScheduleRows(rows).sort((a,b)=> +new Date(a.etd) - +new Date(b.etd));
+      voyageSchedule = normalized;
+      if(meta.label){
+        scheduleLabel.textContent = meta.label;
+      }
+      if(weatherWindows.length){
+        applyWeatherToSchedule();
+        if(meta.note){
+          setInfo(meta.note, meta.tone || 'info');
+        }
+      }else{
+        renderSchedule();
+        const message = meta.note || `스케줄 ${normalized.length}건 로드 완료.`;
+        setInfo(message, meta.tone || 'info');
+      }
+    }
+
+    async function normalizeScheduleViaAI({ files = [], text = '', label = 'AI Normalized', source = 'upload' } = {}){
+      if(!files.length && !text){
+        throw new Error('정규화할 데이터가 없습니다.');
+      }
+      const originalText = scheduleLabel?.textContent;
+      if(scheduleLabel){
+        scheduleLabel.textContent = source === 'paste' ? 'Clipboard 인식 중…' : 'AI 정규화 중…';
+        scheduleLabel.classList.add('animate-pulse');
+      }
+      try{
+        const formData = new FormData();
+        formData.append('model', assistantModelSelect?.value || 'gpt-4.1-mini');
+        if(text){
+          formData.append('text', text.slice(0, 20000));
+        }
+        if(voyageSchedule.length){
+          formData.append('context_schedule', JSON.stringify(voyageSchedule));
+          formData.append('anchor_etd', voyageSchedule[voyageSchedule.length - 1].eta);
+        }
+        files.forEach((file, idx)=>{
+          const name = file.name && file.name.trim() !== ''
+            ? file.name
+            : `capture-${new Date().toISOString().replace(/[.:]/g,'-')}-${idx+1}${guessExtension(file.type || '')}`;
+          formData.append('files', file, name);
+        });
+
+        const res = await fetch(`${apiBase}/api/schedule/normalize`, { method:'POST', body: formData });
+        if(!res.ok){
+          let message = 'Schedule normalization failed';
+          try{
+            const errJson = await res.json();
+            message = errJson?.detail || errJson?.message || JSON.stringify(errJson);
+          }catch(_err){
+            const textErr = await res.text();
+            message = textErr || message;
+          }
+          throw new Error(message);
+        }
+        const data = await res.json();
+        const rows = data?.schedule;
+        if(!Array.isArray(rows) || rows.length === 0){
+          throw new Error('AI가 유효한 스케줄을 반환하지 않았습니다.');
+        }
+        const note = data?.notes || `AI가 ${rows.length}건 스케줄을 정규화했습니다.`;
+        applyScheduleData(rows, { label: `Loaded: ${label}`, note });
+      }catch(err){
+        if(originalText && scheduleLabel){
+          scheduleLabel.textContent = originalText;
+        }
+        throw err;
+      }finally{
+        scheduleLabel?.classList.remove('animate-pulse');
+      }
+    }
+
+    async function processScheduleFile(file, source = 'upload'){
+      if(!file) return;
+      const baseName = file.name && file.name.trim() !== ''
+        ? file.name
+        : `capture-${new Date().toISOString().replace(/[.:]/g,'-')}`;
+      const ext = (file.name || '').toLowerCase();
+      const isJson = ext.endsWith('.json');
+      const isCsv = ext.endsWith('.csv');
+      const isTextLike = isJson || isCsv || (file.type && file.type.startsWith('text/'));
+      let textPayload = '';
+      if(isTextLike){
+        try{
+          textPayload = await file.text();
+        }catch(_err){
+          textPayload = '';
+        }
+      }
+
+      if(isTextLike && textPayload){
+        try{
+          const rows = isJson ? JSON.parse(textPayload) : parseCSV(textPayload);
+          applyScheduleData(rows, { label: `Loaded: ${baseName}` });
+          return;
+        }catch(err){
+          console.warn('Local schedule parsing failed, fallback to AI', err);
+        }
+      }
+
+      try{
+        await normalizeScheduleViaAI({ files: [file], text: textPayload, label: baseName, source });
+      }catch(err){
+        setInfo(`⚠️ 스케줄 정규화 실패: ${err.message}`, 'danger');
+      }
+    }
+
+    let schedulePasteHover = false;
+    if(scheduleDropTarget){
+      ['dragenter','dragover'].forEach(evt=>{
+        scheduleDropTarget.addEventListener(evt,(event)=>{
+          event.preventDefault();
+          scheduleLabel?.classList.add('drag-active');
+        });
+      });
+      ['dragleave','dragend'].forEach(evt=>{
+        scheduleDropTarget.addEventListener(evt,()=>{
+          scheduleLabel?.classList.remove('drag-active');
+        });
+      });
+      scheduleDropTarget.addEventListener('drop', async (event)=>{
+        event.preventDefault();
+        scheduleLabel?.classList.remove('drag-active');
+        const file = event.dataTransfer?.files?.[0];
+        if(file){
+          await processScheduleFile(file, 'drop');
+        }
+      });
+      scheduleDropTarget.addEventListener('mouseenter', ()=>{ schedulePasteHover = true; });
+      scheduleDropTarget.addEventListener('mouseleave', ()=>{ schedulePasteHover = false; });
+    }
 
     async function processWeatherFile(file, source = 'upload'){
       if(!file) return;
@@ -777,40 +941,12 @@
       }
     }
 
-    scheduleInput.addEventListener('change', (e)=>{
-      if(e.target.files.length===0) return;
-      const f = e.target.files[0];
-      const reader = new FileReader();
-      reader.onload = () => {
-        try{
-          let rows;
-          if(f.name.toLowerCase().endsWith('.json')){
-            const data = JSON.parse(reader.result);
-            if(!Array.isArray(data)) throw new Error('JSON must be an array');
-            rows = data;
-          } else {
-            rows = parseCSV(reader.result);
-          }
-          const normalized = rows.map(r=>{
-            const id = r.id || r.Voyage || r.voyage || r.trip || '';
-            const cargo = r.cargo || r.Cargo || '';
-            const etd = r.etd || r.ETD || r.departure || '';
-            const eta = r.eta || r.ETA || r.arrival || '';
-            const status = r.status || r.Status || 'Scheduled';
-            const etdDt = parseISO(etd), etaDt = parseISO(eta);
-            if(!id || !cargo || !etdDt || !etaDt) throw new Error('Missing required fields (id,cargo,etd,eta)');
-            return { id:String(id).trim(), cargo:String(cargo).trim(), etd:fmtIso(etdDt), eta:fmtIso(etaDt), status:String(status).trim() };
-          });
-          voyageSchedule = normalized.sort((a,b)=> +new Date(a.etd)-+new Date(b.etd));
-          scheduleLabel.textContent = `Loaded: ${f.name}`;
-          setInfo(`스케줄 ${normalized.length}건 로드 완료.`, 'info');
-          renderSchedule();
-        }catch(err){
-          console.error(err);
-          setInfo(`⚠️ 스케줄 파일 오류: ${err.message}`, 'danger');
-        }
-      };
-      reader.readAsText(f);
+    scheduleInput?.addEventListener('change', async (e)=>{
+      const inputEl = e.target;
+      const file = inputEl?.files?.[0];
+      if(!file) return;
+      await processScheduleFile(file, 'upload');
+      inputEl.value = '';
     });
 
     weatherInput.addEventListener('change', async (event)=>{
@@ -990,6 +1126,15 @@
 
       event.preventDefault();
       addAttachmentsFromFileList(files);
+      if(schedulePasteHover){
+        try{
+          await processScheduleFile(files[0], 'paste');
+        }catch(err){
+          console.error('Clipboard schedule normalization failed', err);
+          setInfo(`⚠️ 클립보드 스케줄 처리 실패: ${err.message}`, 'danger');
+        }
+        return;
+      }
       try{
         await processWeatherFile(files[0], 'paste');
       }catch(err){

--- a/logistics_control_tower_v2.html
+++ b/logistics_control_tower_v2.html
@@ -8,7 +8,7 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" crossorigin=""/>
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" crossorigin=""></script>
   <style>
-    body{background:#0f172a;color:#e2e8f0;font-family:'Segoe UI',sans-serif}
+    body{background:radial-gradient(circle at top,#1e293b 0%,#0f172a 55%,#020617 100%);color:#e2e8f0;font-family:'Segoe UI',sans-serif}
     .leaflet-container{background:#1f2937;border-radius:.75rem}
     .leaflet-tooltip{background:rgba(15,23,42,.95);color:#fff;border:1px solid #475569;box-shadow:none;font-weight:600;padding:4px 8px}
     .scrollbar-hide::-webkit-scrollbar{display:none}.scrollbar-hide{-ms-overflow-style:none;scrollbar-width:none}
@@ -18,10 +18,20 @@
     .leaflet-tooltip,.leaflet-popup{z-index:500!important}
     .row-current{background:rgba(59,130,246,.15)}
     .kbd{border:1px solid #475569;border-bottom-width:2px;border-radius:.375rem;padding:.15rem .35rem;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
-    .tag{font-size:.75rem;padding:.1rem .4rem;border:1px solid #475569;border-radius:.5rem}
+    .tag{font-size:.75rem;padding:.1rem .4rem;border:1px solid rgba(148,163,184,.6);border-radius:.5rem;background:rgba(148,163,184,.12)}
     .chip{display:inline-flex;align-items:center;gap:.25rem;padding:.25rem .5rem;border-radius:.5rem;background:rgba(79,70,229,.2);color:#c7d2fe;font-size:.75rem}
     .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
     .btn { min-height: 44px; min-width: 44px; } /* 터치 타겟 44px 기준 */
+    .panel-scroll{max-height:clamp(260px,45vh,520px);overflow-y:auto;scrollbar-color:#475569 transparent}
+    .panel-scroll::-webkit-scrollbar{width:6px}
+    .panel-scroll::-webkit-scrollbar-thumb{background:rgba(148,163,184,.45);border-radius:9999px}
+    .pill{display:inline-flex;align-items:center;gap:.25rem;padding:.2rem .6rem;border-radius:9999px;font-weight:600;font-size:.75rem;border:1px solid rgba(94,234,212,.3);background:rgba(45,212,191,.12);color:#a7f3d0;text-transform:uppercase;letter-spacing:.02em}
+    .pill-success{background:rgba(34,197,94,.18);border-color:rgba(34,197,94,.4);color:#bbf7d0}
+    .pill-warn{background:rgba(234,179,8,.22);border-color:rgba(234,179,8,.45);color:#fef3c7}
+    .pill-danger{background:rgba(248,113,113,.2);border-color:rgba(248,113,113,.45);color:#fecaca}
+    #assistant-dropzone{transition:background .2s ease,border-color .2s ease}
+    #assistant-dropzone.drop-active{border-color:rgba(14,165,233,.75);background:rgba(14,165,233,.08);box-shadow:0 0 0 1px rgba(14,165,233,.2)}
+    #assistant-attachments img{box-shadow:0 4px 12px rgba(15,23,42,.65)}
 
     @media (prefers-contrast: more) {
         :root {
@@ -30,11 +40,11 @@
             --muted: #e2e8f0;
         }
         .panel, .status-card, .control-card { border-color: rgba(255,255,255,0.6); }
-        .pill { background: rgba(0,180,255,0.25); }
+        .pill, .pill-success, .pill-warn, .pill-danger { border-color: rgba(255,255,255,0.7); }
     }
   </style>
 </head>
-<body class="p-4">
+<body class="p-4" data-api-base-url="http://localhost:8000">
   <!-- Skip link for keyboard users -->
   <a href="#main" class="sr-only" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;"
      onfocus="this.style.position='static';this.style.width='auto';this.style.height='auto';this.style.padding='0.5rem 0.75rem';this.style.background='#0ea5e9';this.style.color='#000';this.style.borderRadius='8px';">
@@ -45,15 +55,15 @@
          role="img" aria-label="Vessel tracking map showing route from MW4 to AGI" tabindex="0"></div>
 
     <aside class="lg:col-span-2 flex flex-col gap-4 h-full" role="complementary" aria-label="Vessel control and schedule information">
-      <div id="info-panel" class="bg-slate-900 p-4 rounded-xl shadow-lg border border-slate-700">
+      <div id="info-panel" class="bg-slate-900/90 p-4 rounded-xl shadow-2xl border border-slate-700 panel-scroll backdrop-blur-sm space-y-4">
         <div class="flex items-center justify-between">
           <h2 class="text-xl font-bold border-b border-slate-600 pb-2 mb-3">Vessel Control</h2>
           <div class="flex items-center gap-2">
             <span class="tag">Local: Asia/Dubai</span>
-            <div class="pill" id="marineBadge" title="Marine snapshot">Hs: -- m · Wind: -- kt</div>
+            <div class="pill pill-warn" id="marineBadge" title="Marine snapshot">Hs: -- m · Wind: -- kt</div>
           </div>
         </div>
-        <div id="vessel-info"><p class="text-slate-400">Loading vessel data...</p></div>
+        <div id="vessel-info" class="space-y-4"><p class="text-slate-400">Loading vessel data...</p></div>
 
         <div class="grid grid-cols-2 gap-2 mt-4">
           <button id="briefing-btn" class="w-full bg-indigo-600 hover:bg-indigo-700 text-white font-bold py-2 px-3 rounded-lg transition-colors flex items-center justify-center gap-2 text-sm"
@@ -70,11 +80,32 @@
             <span id="label-schedule" class="w-full inline-flex items-center justify-center bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-3 rounded-lg cursor-pointer">Upload Schedule (CSV/JSON)</span>
           </label>
           <label class="w-full">
-            <input type="file" id="file-weather" class="hidden" accept=".csv"/>
-            <span id="label-weather" class="w-full inline-flex items-center justify-center bg-emerald-600 hover:bg-emerald-700 text-white font-bold py-2 px-3 rounded-lg cursor-pointer">Upload Weather (CSV)</span>
+            <input type="file" id="file-weather" class="hidden" accept=".csv,image/*"/>
+            <span id="label-weather" class="w-full inline-flex items-center justify-center bg-emerald-600 hover:bg-emerald-700 text-white font-bold py-2 px-3 rounded-lg cursor-pointer drop-zone">Upload Weather (CSV / Image)</span>
           </label>
         </div>
-        <p class="mt-3 text-xs text-slate-400">Tips: Press <span class="kbd">Esc</span> to close modals. 파일 포맷은 하단 가이드를 참고. API는 <span class="chip" id="api-status">API: Offline</span></p>
+        <div class="mt-3 space-y-2 text-xs text-slate-400">
+          <p>Tips: Press <span class="kbd">Esc</span> to close modals. 파일 포맷은 하단 가이드를 참고.</p>
+          <div class="flex items-center justify-between gap-2">
+            <div>API 상태 <span class="chip" id="api-status">API: Offline</span></div>
+            <button id="api-config-btn" class="px-2 py-1 rounded bg-slate-800/70 hover:bg-slate-700 text-slate-100 border border-slate-600 text-[11px] font-semibold">API 설정</button>
+          </div>
+        </div>
+        <div class="bg-slate-800/60 border border-slate-700 rounded-lg p-3 text-xs text-slate-200" aria-live="polite">
+          <div class="flex items-center justify-between">
+            <span class="font-semibold">Inline Attachments</span>
+            <span class="text-slate-500 text-[11px]">Ctrl/⌘+V 로 캡처를 붙여넣으세요</span>
+          </div>
+          <div id="attachments" class="mt-2 space-y-2 text-slate-300"></div>
+        </div>
+      </div>
+
+      <div id="ai-analysis-panel" class="bg-slate-900/90 p-4 rounded-xl shadow-xl border border-slate-700 hidden" role="region" aria-label="AI weather analysis">
+        <div class="flex items-center justify-between border-b border-slate-600 pb-2 mb-3">
+          <h2 class="text-xl font-bold text-sky-300">✨ AI Weather Insight</h2>
+          <span class="tag text-xs">Screenshot Ready</span>
+        </div>
+        <div id="analysis-content" class="text-slate-200 bg-slate-950/80 rounded-lg p-3 text-sm leading-relaxed whitespace-pre-line"></div>
       </div>
 
       <div class="bg-slate-900 p-4 rounded-xl shadow-lg border border-slate-700 flex-grow flex flex-col h-1/2">
@@ -150,13 +181,14 @@
       <div id="assistant-conversation" class="flex-grow bg-slate-950 p-4 rounded-md overflow-y-auto scrollbar-hide space-y-2 text-sm">
         <div class="text-slate-400">무엇을 도와드릴까요? (예: “다음 3일 스케줄 요약”)<br/>첨부 버튼으로 캡처/문서를 추가하면 자동 분석됩니다.</div>
       </div>
-      <div class="mt-3 bg-slate-800/60 border border-slate-600 rounded-lg p-3">
+      <div id="assistant-dropzone" class="mt-3 bg-slate-800/60 border border-dashed border-slate-600 rounded-lg p-3">
         <div class="flex items-center justify-between">
           <div class="text-xs text-slate-300 font-semibold">Attachments</div>
           <button id="assistant-attach-btn" class="text-xs bg-slate-700 hover:bg-slate-600 text-white px-2 py-1 rounded">+ Add</button>
         </div>
+        <p class="mt-2 text-[11px] text-slate-400">+ 버튼을 누르거나 파일을 끌어다 놓고, 스크린 캡처는 붙여넣기(Ctrl/⌘+V)로 추가하세요.</p>
         <input type="file" id="assistant-file" class="hidden" accept="image/*,.pdf,.txt,.csv" multiple />
-        <div id="assistant-attachments" class="mt-2 text-xs text-slate-400 space-y-1"></div>
+        <div id="assistant-attachments" class="mt-3 text-xs text-slate-300 space-y-2 min-h-[3rem]" aria-live="polite"></div>
       </div>
       <form id="assistant-form" class="mt-3 flex gap-2" role="form" aria-label="AI Assistant Chat">
         <input type="text" id="assistant-input" class="flex-grow bg-slate-800 text-white rounded-lg p-2 border border-slate-600 focus:outline-none focus:ring-2 focus:ring-purple-500" 
@@ -179,7 +211,11 @@
     window.cancelIdleCallback ||= (id)=>clearTimeout(id);
 
   document.addEventListener('DOMContentLoaded', () => {
-    const API_BASE = window.APP_CONFIG?.apiBase ?? 'http://localhost:8000';
+    const apiStorageKey = 'hvdc.apiBaseUrl';
+    const defaultApiBase = window.APP_CONFIG?.apiBase ?? document.body.dataset.apiBaseUrl ?? 'http://localhost:8000';
+    let apiBase = localStorage.getItem(apiStorageKey) || defaultApiBase;
+    const apiStatusChip = document.getElementById('api-status');
+    const apiConfigBtn = document.getElementById('api-config-btn');
     const tz = 'Asia/Dubai';
     
     // Scenario presets and port coordinates
@@ -197,6 +233,8 @@
       'Colombo':    { lat: 6.9271,  lon: 79.8612  },
       'Jebel Ali':  { lat: 25.006,  lon: 55.065   }
     };
+    const MARINE_CACHE_TTL_MS = 5 * 60 * 1000;
+    const marineSnapshotCache = new Map();
     const fmtIso = (d)=> new Date(d).toISOString();
     const toLocal = (d)=> new Date(d).toLocaleString('en-GB',{ timeZone: tz, dateStyle:'short', timeStyle:'medium' });
     const pad2 = (n)=> String(n).padStart(2,'0');
@@ -218,22 +256,59 @@
       });
     };
 
-    async function checkApiHealth(){
-      const badge = document.getElementById('api-status');
+    function formatBaseLabel(url){
       try{
-        const res = await fetch(`${API_BASE}/health`);
+        const { hostname, port } = new URL(url);
+        return port ? `${hostname}:${port}` : hostname;
+      }catch(_err){
+        return url;
+      }
+    }
+
+    async function checkApiHealth(){
+      if(!apiStatusChip) return;
+      const label = formatBaseLabel(apiBase);
+      apiStatusChip.textContent = `API: Checking… @ ${label}`;
+      apiStatusChip.classList.remove('bg-rose-500/40','bg-emerald-500/40','text-emerald-200');
+      apiStatusChip.classList.add('bg-slate-700/70');
+      try{
+        const controller = new AbortController();
+        const timer = setTimeout(()=>controller.abort(), 5000);
+        const res = await fetch(`${apiBase}/health`, { signal: controller.signal });
+        clearTimeout(timer);
         if(res.ok){
-          badge.textContent = 'API: Online';
-          badge.classList.remove('bg-rose-500/40');
-          badge.classList.add('bg-emerald-500/40','text-emerald-200');
+          apiStatusChip.textContent = `API: Online @ ${label}`;
+          apiStatusChip.classList.remove('bg-slate-700/70','bg-rose-500/40');
+          apiStatusChip.classList.add('bg-emerald-500/40','text-emerald-200');
         }else{
-          throw new Error('Healthcheck failed');
+          throw new Error(`Healthcheck failed (${res.status})`);
         }
       }catch(err){
-        badge.textContent = 'API: Offline';
-        badge.classList.remove('bg-emerald-500/40','text-emerald-200');
-        badge.classList.add('bg-rose-500/40');
+        apiStatusChip.textContent = `API: Offline @ ${label}`;
+        apiStatusChip.classList.remove('bg-slate-700/70','bg-emerald-500/40','text-emerald-200');
+        apiStatusChip.classList.add('bg-rose-500/40');
+        console.warn('API health check failed', err);
       }
+    }
+
+    function persistApiBase(newUrl){
+      if(!newUrl) return;
+      apiBase = newUrl.replace(/\/$/, '');
+      localStorage.setItem(apiStorageKey, apiBase);
+      checkApiHealth();
+    }
+
+    if(apiConfigBtn){
+      apiConfigBtn.addEventListener('click', ()=>{
+        const input = prompt('OpenAI Gateway URL을 입력하세요', apiBase);
+        if(!input) return;
+        try{ new URL(input); } catch(_err){ alert('유효한 URL이 아닙니다.'); return; }
+        persistApiBase(input);
+      });
+      apiConfigBtn.addEventListener('contextmenu',(event)=>{
+        event.preventDefault();
+        persistApiBase(defaultApiBase);
+      });
     }
 
     checkApiHealth();
@@ -304,22 +379,61 @@
     const timeDisplay = document.getElementById('sim-time');
     const scheduleContainer = document.getElementById('schedule-container');
     const alertContainer = document.getElementById('alert-container');
+    const aiAnalysisPanel = document.getElementById('ai-analysis-panel');
+    const analysisContent = document.getElementById('analysis-content');
     const assistantConversation = document.getElementById('assistant-conversation');
     const assistantUsage = document.getElementById('assistant-usage');
     const assistantFileInput = document.getElementById('assistant-file');
     const assistantAttachments = document.getElementById('assistant-attachments');
+    const assistantDropzone = document.getElementById('assistant-dropzone');
     const assistantModelSelect = document.getElementById('assistant-model');
+    const inlineAttachmentsPanel = document.getElementById('attachments');
     let assistantHistory = [];
     let pendingAttachments = [];
 
     function updateInfoPanel(){
       const cur=vesselData.currentVoyageId||'N/A';
+      const activeLeg = voyageSchedule.find(v=>v.id===vesselData.currentVoyageId);
+      const progressRatio = clamp(vesselData.progress ?? 0,0,1);
+      const progressPct = progressRatio * 100;
+      const etdDisplay = activeLeg?.etd ? toLocal(activeLeg.etd) : 'N/A';
+      const etaDisplay = activeLeg?.eta ? toLocal(activeLeg.eta) : 'N/A';
       infoPanel.innerHTML =
-        `<h3 class="text-2xl font-bold text-cyan-400">${vesselData.name}</h3>
-         <p class="text-sm text-slate-400">IMO: ${vesselData.imo} / MMSI: ${vesselData.mmsi}</p>
-         <div class="mt-4 space-y-2">
-           <div><strong>Current Voyage:</strong> <span class="font-mono text-lg">${cur}</span></div>
-           <div><strong>Status:</strong> <span class="font-mono text-lg text-yellow-300">${vesselData.status}</span></div>
+        `<div class="flex items-start justify-between gap-3">
+           <div>
+             <h3 class="text-2xl font-bold text-cyan-400">${vesselData.name}</h3>
+             <p class="text-sm text-slate-400">IMO: ${vesselData.imo} / MMSI: ${vesselData.mmsi}</p>
+           </div>
+           <span class="px-2 py-1 rounded-md text-xs bg-slate-800/80 border border-slate-600">${tz}</span>
+         </div>
+         <div class="grid grid-cols-2 gap-3 text-sm">
+           <div class="bg-slate-800/60 border border-slate-700 rounded-lg p-3">
+             <p class="text-slate-400 text-xs uppercase tracking-wider">Current Voyage</p>
+             <p class="mt-1 font-mono text-lg text-emerald-300">${cur}</p>
+           </div>
+           <div class="bg-slate-800/60 border border-slate-700 rounded-lg p-3">
+             <p class="text-slate-400 text-xs uppercase tracking-wider">Status</p>
+             <p class="mt-1 font-semibold text-sky-300">${vesselData.status}</p>
+           </div>
+         </div>
+         <div class="bg-slate-800/60 border border-slate-700 rounded-lg p-3">
+           <div class="flex items-center justify-between text-xs text-slate-400">
+             <span>Leg Progress</span>
+             <span class="font-mono text-slate-200">${progressPct.toFixed(2)}%</span>
+          </div>
+          <div class="w-full h-2 bg-slate-900/80 rounded-full mt-2">
+             <div class="h-2 rounded-full bg-gradient-to-r from-cyan-400 via-sky-500 to-emerald-400" style="width:${Math.min(100,Math.max(0,progressPct)).toFixed(2)}%"></div>
+           </div>
+           <div class="mt-3 grid grid-cols-2 gap-2 text-xs text-slate-400">
+             <div>
+               <span class="block uppercase tracking-wide">ETD</span>
+               <span class="font-mono text-slate-200">${etdDisplay}</span>
+             </div>
+             <div>
+               <span class="block uppercase tracking-wide">ETA</span>
+               <span class="font-mono text-slate-200">${etaDisplay}</span>
+             </div>
+           </div>
          </div>`;
     }
 
@@ -330,6 +444,9 @@
       document.getElementById('schedule-container').setAttribute('aria-busy','true');
       scheduleBody.innerHTML = '';
       
+      const marineSnap = await updateMarineForLeg('Jebel Ali');
+      const baseIoi = Number.isFinite(marineSnap?.ioi) ? Number(marineSnap.ioi) : 50;
+
       for (let index = 0; index < voyageSchedule.length; index += 1) {
         const v = voyageSchedule[index];
         let c="text-slate-300", pill="";
@@ -337,14 +454,14 @@
         else if(v.status==="Delayed") { c="text-rose-300"; pill='<span class="tag">Delayed</span>'; }
         else if(v.status==="Completed") { c="text-emerald-300"; pill='<span class="tag">Arrived</span>'; }
         const hi=v.id===vesselData.currentVoyageId ? "row-current" : "";
-        
+
         // Marine data for this port (simplified for current structure)
-        const snap = await updateMarineForLeg('Jebel Ali'); // Default port for now
-        const ioi = snap?.ioi ?? 50;
-        const decision = ioi >= 75 ? { tag: 'Go', tone: 'success' } : 
-                        ioi >= 55 ? { tag: 'Caution', tone: 'warn' } : 
+        const ioi = baseIoi;
+        const decision = ioi >= 75 ? { tag: 'Go', tone: 'success' } :
+                        ioi >= 55 ? { tag: 'Caution', tone: 'warn' } :
                         { tag: 'No-Go', tone: 'danger' };
-        
+        const formattedIoi = Number.isFinite(ioi) ? Number(ioi).toFixed(2) : '50.00';
+
         const row = document.createElement('tr');
         row.id = `voyage-${v.id}`;
         row.className = `border-t border-slate-700 ${hi}`;
@@ -355,8 +472,8 @@
           <td class="p-2" role="gridcell" aria-describedby="th-etd">${toLocal(v.etd)}</td>
           <td class="p-2" role="gridcell" aria-describedby="th-eta">${toLocal(v.eta)}</td>
           <td class="p-2 ${c} font-semibold" role="gridcell" aria-describedby="th-status">${v.status} ${pill}</td>
-          <td class="p-2" role="gridcell" aria-describedby="th-ioi">${ioi}</td>
-          <td class="p-2" role="gridcell" aria-describedby="th-decision"><span class="pill ${decision.tone === 'danger' ? 'danger' : ''}">${decision.tag}</span></td>
+          <td class="p-2" role="gridcell" aria-describedby="th-ioi">${formattedIoi}</td>
+          <td class="p-2" role="gridcell" aria-describedby="th-decision"><span class="pill pill-${decision.tone}">${decision.tag}</span></td>
         `;
         scheduleBody.appendChild(row);
       }
@@ -497,9 +614,66 @@
     const weatherInput  = document.getElementById('file-weather');
     const scheduleLabel = document.getElementById('label-schedule');
     const weatherLabel  = document.getElementById('label-weather');
+    const weatherDropTarget = weatherLabel?.parentElement || weatherLabel;
+    const weatherBusyClasses = ['bg-amber-500','hover:bg-amber-500','animate-pulse'];
+    const weatherReadyClasses = ['bg-emerald-600','hover:bg-emerald-700'];
 
     scheduleLabel.addEventListener('click',()=> scheduleInput.click());
     weatherLabel.addEventListener('click',()=> weatherInput.click());
+
+    async function processWeatherFile(file, source = 'upload'){
+      if(!file) return;
+      const baseName = file.name && file.name.trim() !== ''
+        ? file.name
+        : `capture-${new Date().toISOString().replace(/[.:]/g,'-')}`;
+      const name = baseName;
+      const isImage = (file.type && file.type.startsWith('image/')) || /\.(png|jpg|jpeg|webp|gif)$/i.test(name);
+
+      const setLabel = (text, stateClasses)=>{
+        if(!weatherLabel) return;
+        weatherLabel.textContent = text;
+        weatherLabel.classList.remove(...weatherBusyClasses, ...weatherReadyClasses);
+        if(stateClasses && stateClasses.length){
+          weatherLabel.classList.add(...stateClasses);
+        }
+      };
+
+      if(isImage){
+        setLabel(source === 'paste' ? 'Clipboard 분석 중…' : 'Analyzing screenshot...', weatherBusyClasses);
+        try{
+          const prompt = `You are an expert marine logistics AI. Analyze the attached weather report image named "${name}" and summarise the highest risk window, dominant hazards, and the expected schedule impact for JOPETWIL 71. Respond in Korean with bullet points.`;
+          const insight = await callAssistant(prompt, [file], { persist: false, historyOverride: [] });
+          analysisContent.innerHTML = insight.replace(/\n/g,'<br>');
+          aiAnalysisPanel.classList.remove('hidden');
+          weatherLinked = true;
+          setInfo('ADNOC 스크린샷 분석 완료. 리스크 모니터링이 활성화되었습니다.', 'warn');
+        }catch(err){
+          console.error(err);
+          aiAnalysisPanel.classList.add('hidden');
+          analysisContent.innerHTML = '';
+          setInfo(`⚠️ 스크린샷 분석 실패: ${err.message}`, 'danger');
+        }finally{
+          setLabel(`Loaded: ${name}`, weatherReadyClasses);
+        }
+        return;
+      }
+
+      try{
+        setLabel('Parsing forecast...', weatherBusyClasses);
+        const text = await file.text();
+        const rows = parseCSV(text);
+        buildWeatherWindows(rows);
+        setLabel(`Loaded: ${name}`, weatherReadyClasses);
+        weatherLinked = true;
+        aiAnalysisPanel.classList.add('hidden');
+        analysisContent.innerHTML = '';
+        applyWeatherToSchedule();
+      }catch(err){
+        console.error(err);
+        setLabel('Upload Weather (CSV / Image)', weatherReadyClasses);
+        setInfo(`⚠️ 날씨 파일 오류: ${err.message}`, 'danger');
+      }
+    }
 
     scheduleInput.addEventListener('change', (e)=>{
       if(e.target.files.length===0) return;
@@ -537,24 +711,34 @@
       reader.readAsText(f);
     });
 
-    weatherInput.addEventListener('change', (e)=>{
-      if(e.target.files.length===0) return;
-      const f = e.target.files[0];
-      const reader = new FileReader();
-      reader.onload = ()=>{
-        try{
-          const rows = parseCSV(reader.result);
-          buildWeatherWindows(rows);
-          weatherLabel.textContent = `Loaded: ${f.name}`;
-          weatherLinked = true;
-          applyWeatherToSchedule();
-        }catch(err){
-          console.error(err);
-          setInfo(`⚠️ 날씨 파일 오류: ${err.message}`, 'danger');
-        }
-      };
-      reader.readAsText(f);
+    weatherInput.addEventListener('change', async (event)=>{
+      const files = event.target.files || [];
+      if(files.length === 0) return;
+      await processWeatherFile(files[0], 'upload');
+      weatherInput.value = '';
     });
+
+    if(weatherDropTarget){
+      ['dragenter','dragover'].forEach(evt=>{
+        weatherDropTarget.addEventListener(evt,(event)=>{
+          event.preventDefault();
+          weatherLabel?.classList.add('drag-active');
+        });
+      });
+      ['dragleave','dragend'].forEach(evt=>{
+        weatherDropTarget.addEventListener(evt,()=>{
+          weatherLabel?.classList.remove('drag-active');
+        });
+      });
+      weatherDropTarget.addEventListener('drop', async (event)=>{
+        event.preventDefault();
+        weatherLabel?.classList.remove('drag-active');
+        const file = event.dataTransfer?.files?.[0];
+        if(file){
+          await processWeatherFile(file, 'drop');
+        }
+      });
+    }
 
     const briefingModal=document.getElementById('briefing-modal');
     const assistantModal=document.getElementById('assistant-modal');
@@ -579,55 +763,163 @@
     [briefingModal,assistantModal].forEach(m=> m.addEventListener('click', e=>{ if(e.target===m) closeModal(m); }));
     document.addEventListener('keydown', e=>{ if(e.key==='Escape'){ [briefingModal,assistantModal].forEach(closeModal); } });
 
-    function renderAttachmentList(){
-      if(pendingAttachments.length===0){
-        assistantAttachments.innerHTML = '<div class="text-slate-500">No attachments selected.</div>';
-        return;
-      }
-      assistantAttachments.innerHTML = pendingAttachments.map((file,idx)=>{
-        return `<div class="flex justify-between items-center bg-slate-900/80 px-2 py-1 rounded">
-                  <span class="truncate max-w-[14rem]">${file.name}</span>
-                  <button data-index="${idx}" class="text-rose-300 hover:text-rose-400 remove-attachment">Remove</button>
+    function guessExtension(type){
+      if(!type) return '';
+      if(type.includes('png')) return '.png';
+      if(type.includes('jpeg') || type.includes('jpg')) return '.jpg';
+      if(type.includes('gif')) return '.gif';
+      if(type.includes('webp')) return '.webp';
+      if(type.includes('pdf')) return '.pdf';
+      if(type.includes('csv')) return '.csv';
+      if(type.includes('plain')) return '.txt';
+      return '';
+    }
+
+    function buildAttachmentMarkup(){
+      return pendingAttachments.map((file,idx)=>{
+        const isImage = (file.type || '').startsWith('image/');
+        const preview = isImage
+          ? (()=>{
+              const blob = URL.createObjectURL(file);
+              return `<img src="${blob}" alt="${file.name} preview" class="w-12 h-12 object-cover rounded-md border border-slate-700" onload="URL.revokeObjectURL(this.src)">`;
+            })()
+          : '<span class="w-12 h-12 flex items-center justify-center rounded-md bg-slate-900/70 border border-slate-700 text-lg">📄</span>';
+        const sizeKb = file.size ? (file.size/1024).toFixed(2) : '0.00';
+        return `<div class="flex items-center gap-3 bg-slate-900/70 px-3 py-2 rounded-lg border border-slate-800/70">
+                  ${preview}
+                  <div class="flex-1 min-w-0">
+                    <p class="text-slate-200 text-sm truncate">${file.name}</p>
+                    <p class="text-slate-500 text-[11px]">${file.type || 'unknown'} • ${sizeKb} KB</p>
+                  </div>
+                  <button data-index="${idx}" class="text-rose-300 hover:text-rose-200 text-xs remove-attachment">Remove</button>
                 </div>`;
       }).join('');
-      assistantAttachments.querySelectorAll('.remove-attachment').forEach(btn=>{
-        btn.addEventListener('click',(ev)=>{
-          const idx = Number(ev.target.getAttribute('data-index'));
-          pendingAttachments.splice(idx,1);
-          renderAttachmentList();
+    }
+
+    function addAttachmentsFromFileList(fileList){
+      const files = Array.from(fileList || []);
+      if(files.length===0) return;
+      const stamped = files.map((file,idx)=>{
+        if(file.name) return file;
+        const ext = guessExtension(file.type || '');
+        const timestamp = new Date().toISOString().replace(/[.:]/g,'-');
+        return new File([file], `capture-${timestamp}-${idx+1}${ext}`, { type: file.type || 'application/octet-stream' });
+      });
+      pendingAttachments = pendingAttachments.concat(stamped);
+      renderAttachmentList();
+    }
+
+    function renderAttachmentList(){
+      const containers = [assistantAttachments, inlineAttachmentsPanel].filter(Boolean);
+      if(pendingAttachments.length===0){
+        const emptyState = '<div class="text-slate-500 text-[11px]">첨부된 파일이 없습니다. 스크린 캡처 붙여넣기를 지원합니다.</div>';
+        containers.forEach(container=>{ container.innerHTML = emptyState; });
+        return;
+      }
+      containers.forEach(container=>{
+        container.innerHTML = buildAttachmentMarkup();
+        container.querySelectorAll('.remove-attachment').forEach(btn=>{
+          btn.addEventListener('click',(ev)=>{
+            const idx = Number(ev.currentTarget.getAttribute('data-index'));
+            pendingAttachments.splice(idx,1);
+            renderAttachmentList();
+          });
         });
       });
     }
 
-    assistantAttachments.innerHTML = '<div class="text-slate-500">No attachments selected.</div>';
+    renderAttachmentList();
 
     document.getElementById('assistant-attach-btn').addEventListener('click', ()=> assistantFileInput.click());
     assistantFileInput.addEventListener('change', (event)=>{
-      pendingAttachments = Array.from(event.target.files || []);
-      renderAttachmentList();
+      addAttachmentsFromFileList(event.target.files || []);
+      assistantFileInput.value = '';
+    });
+
+    ['dragenter','dragover'].forEach(evt=>{
+      assistantDropzone.addEventListener(evt,(event)=>{
+        event.preventDefault();
+        assistantDropzone.classList.add('drop-active');
+      });
+    });
+    ['dragleave','dragend'].forEach(evt=>{
+      assistantDropzone.addEventListener(evt,()=>{
+        assistantDropzone.classList.remove('drop-active');
+      });
+    });
+    assistantDropzone.addEventListener('drop',(event)=>{
+      event.preventDefault();
+      assistantDropzone.classList.remove('drop-active');
+      addAttachmentsFromFileList(event.dataTransfer?.files || []);
+    });
+
+    document.addEventListener('paste', async (event)=>{
+      const items = event.clipboardData?.items || [];
+      const files = [];
+      for(const item of items){
+        if(item.kind === 'file'){
+          const file = item.getAsFile();
+          if(file) files.push(file);
+        }
+      }
+      if(files.length === 0) return;
+
+      const assistantVisible = assistantModal.getAttribute('aria-hidden') !== 'true';
+      if(assistantVisible){
+        event.preventDefault();
+        addAttachmentsFromFileList(files);
+        return;
+      }
+
+      const activeEl = document.activeElement;
+      if(activeEl && ['INPUT','TEXTAREA'].includes(activeEl.tagName) && activeEl !== document.body){
+        return; // allow normal paste in text inputs when assistant closed
+      }
+
+      event.preventDefault();
+      addAttachmentsFromFileList(files);
+      try{
+        await processWeatherFile(files[0], 'paste');
+      }catch(err){
+        console.error('Clipboard weather upload failed', err);
+      }
     });
 
     document.getElementById('assistant-reset').addEventListener('click', ()=>{
       assistantHistory = [];
       assistantConversation.innerHTML = '<div class="text-slate-400">무엇을 도와드릴까요? (예: “다음 3일 스케줄 요약”)</div>';
       assistantUsage.textContent='';
+      pendingAttachments = [];
+      renderAttachmentList();
     });
 
-    async function callAssistant(prompt, attachments){
+    async function callAssistant(prompt, attachments, options = {}){
+      const { persist = true, historyOverride = assistantHistory, model = assistantModelSelect.value } = options;
       const formData = new FormData();
       formData.append('prompt', prompt);
-      formData.append('history', JSON.stringify(assistantHistory));
-      formData.append('model', assistantModelSelect.value);
-      attachments.forEach(file=> formData.append('files', file, file.name));
-      const res = await fetch(`${API_BASE}/api/assistant`, { method:'POST', body: formData });
+      formData.append('history', JSON.stringify(historyOverride));
+      formData.append('model', model);
+      attachments.forEach(file=> formData.append('files', file, file.name || 'attachment'));
+      const res = await fetch(`${apiBase}/api/assistant`, { method:'POST', body: formData });
       if(!res.ok){
-        const text = await res.text();
-        throw new Error(text || 'Assistant call failed');
+        let message = 'Assistant call failed';
+        try{
+          const errJson = await res.json();
+          message = errJson?.detail || errJson?.message || JSON.stringify(errJson);
+        }catch(_err){
+          const text = await res.text();
+          message = text || message;
+        }
+        throw new Error(message);
       }
       const data = await res.json();
-      assistantHistory.push({role:'user', content: prompt});
-      assistantHistory.push({role:'assistant', content: data.answer});
-      assistantUsage.textContent = `Last response model: ${assistantModelSelect.value}`;
+      if(!data?.answer){
+        throw new Error('AI 응답이 비어 있습니다.');
+      }
+      if(persist){
+        assistantHistory = [...historyOverride, {role:'user', content: prompt}, {role:'assistant', content: data.answer}];
+        assistantUsage.textContent = `Last response model: ${model}`;
+      }
       return data.answer;
     }
 
@@ -648,15 +940,26 @@
           waveM: w.waveM,
           windKt: w.windKt,
           visKm: w.visKm
-        }))
+        })),
+        model: assistantModelSelect.value
       };
       try{
-        const res = await fetch(`${API_BASE}/api/briefing`, {
+        const res = await fetch(`${apiBase}/api/briefing`, {
           method:'POST',
           headers:{'Content-Type':'application/json'},
           body: JSON.stringify(payload)
         });
-        if(!res.ok) throw new Error(await res.text());
+        if(!res.ok){
+          let message = 'Briefing call failed';
+          try{
+            const errJson = await res.json();
+            message = errJson?.detail || errJson?.message || JSON.stringify(errJson);
+          }catch(_err){
+            const text = await res.text();
+            message = text || message;
+          }
+          throw new Error(message);
+        }
         const data = await res.json();
         modalContent.innerHTML = data.briefing.replace(/\n/g,'<br>');
       }catch(err){
@@ -671,7 +974,7 @@
       const prompt = `다음 일정과 기상창을 기반으로 3가지 위험 시나리오와 대응 권고를 bullet로 정리해줘.\n일정: ${JSON.stringify(voyageSchedule)}\n기상: ${JSON.stringify(weatherWindows)}`;
       setInfo('AI 위험 스캔 실행 중...', 'info');
       try{
-        const answer = await callAssistant(prompt, []);
+        const answer = await callAssistant(prompt, [], { persist: false });
         setInfo(answer.replace(/\n/g,'<br>'), 'warn');
       }catch(err){
         setInfo(`AI 위험 스캔 실패: ${err.message}`, 'danger');
@@ -712,14 +1015,33 @@
     });
 
     // Marine data functions
+    function applyMarineBadge(snap) {
+      const badge = document.getElementById('marineBadge');
+      badge.classList.remove('pill-success','pill-warn','pill-danger');
+      let tone = 'warn';
+      if (snap && typeof snap.ioi === 'number') {
+        if (snap.ioi >= 75) tone = 'success';
+        else if (snap.ioi < 55) tone = 'danger';
+      }
+      badge.classList.add(`pill-${tone}`);
+      if (snap && snap.hs != null && snap.windKt != null) {
+        badge.textContent = `Hs: ${snap.hs.toFixed(2)} m · Wind: ${snap.windKt.toFixed(2)} kt`;
+      } else {
+        badge.textContent = `Marine: n/a`;
+      }
+    }
+
     async function updateMarineForLeg(portName) {
+      const now = Date.now();
+      const cached = marineSnapshotCache.get(portName);
+      if (cached && (now - cached.timestamp) < MARINE_CACHE_TTL_MS) {
+        applyMarineBadge(cached.snap);
+        return cached.snap;
+      }
       // 워커로 오프로드
       const snap = await fetchMarineAndIOIInWorker(portName);
-      if (snap && snap.hs != null && snap.windKt != null) {
-        marineBadge.textContent = `Hs: ${snap.hs.toFixed(2)} m · Wind: ${Math.round(snap.windKt)} kt`;
-      } else {
-        marineBadge.textContent = `Marine: n/a`;
-      }
+      marineSnapshotCache.set(portName, { snap, timestamp: now });
+      applyMarineBadge(snap);
       return snap;
     }
 

--- a/logistics_control_tower_v2.html
+++ b/logistics_control_tower_v2.html
@@ -255,13 +255,31 @@
       return isNaN(Date.parse(t)) ? null : new Date(t);
     };
     const parseCSV = (text)=>{
-      const lines = text.trim().split(/\r?\n/);
-      const header = lines.shift().split(',').map(h=>h.trim());
+      const lines = text.trim().split(/\r?\n/).filter(Boolean);
+      if(lines.length === 0) return [];
+      const firstCells = lines[0].split(',').map(c=>c.trim().replace(/^\ufeff/, ''));
+      const canonical = ['id','cargo','etd','eta','status'];
+      const headerSet = new Set(firstCells.map(cell=>cell.toLowerCase()));
+      const headerDetected =
+        canonical.some(col=>headerSet.has(col)) || headerSet.has('voyage');
+      if(headerDetected){
+        const header = firstCells;
+        return lines.slice(1).map(line=>{
+          const cells = line.split(',').map(c=>c.trim());
+          const obj={};
+          header.forEach((h,i)=>{ obj[h]=cells[i]; });
+          return obj;
+        });
+      }
       return lines.map(line=>{
         const cells = line.split(',').map(c=>c.trim());
-        const obj={};
-        header.forEach((h,i)=> obj[h]=cells[i]);
-        return obj;
+        return {
+          id: cells[0] || '',
+          cargo: cells[1] || '',
+          etd: cells[2] || '',
+          eta: cells[3] || '',
+          status: cells[4] || 'Scheduled'
+        };
       });
     };
 

--- a/logistics_control_tower_v2.html
+++ b/logistics_control_tower_v2.html
@@ -29,6 +29,9 @@
     .pill-success{background:rgba(34,197,94,.18);border-color:rgba(34,197,94,.4);color:#bbf7d0}
     .pill-warn{background:rgba(234,179,8,.22);border-color:rgba(234,179,8,.45);color:#fef3c7}
     .pill-danger{background:rgba(248,113,113,.2);border-color:rgba(248,113,113,.45);color:#fecaca}
+    .gantt-track{height:.4rem;background:rgba(30,41,59,.85);border-radius:9999px;overflow:hidden}
+    .gantt-fill{height:100%;background:linear-gradient(90deg,#38bdf8,#818cf8);border-radius:9999px;transition:width .3s ease}
+    .drag-active{border-color:rgba(14,165,233,.75)!important;box-shadow:0 0 0 1px rgba(14,165,233,.35)}
     #assistant-dropzone{transition:background .2s ease,border-color .2s ease}
     #assistant-dropzone.drop-active{border-color:rgba(14,165,233,.75);background:rgba(14,165,233,.08);box-shadow:0 0 0 1px rgba(14,165,233,.2)}
     #assistant-attachments img{box-shadow:0 4px 12px rgba(15,23,42,.65)}
@@ -44,7 +47,7 @@
     }
   </style>
 </head>
-<body class="p-4" data-api-base-url="http://localhost:8000">
+  <body class="p-4" data-api-base-url="http://localhost:8002">
   <!-- Skip link for keyboard users -->
   <a href="#main" class="sr-only" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;"
      onfocus="this.style.position='static';this.style.width='auto';this.style.height='auto';this.style.padding='0.5rem 0.75rem';this.style.background='#0ea5e9';this.style.color='#000';this.style.borderRadius='8px';">
@@ -63,7 +66,7 @@
             <div class="pill pill-warn" id="marineBadge" title="Marine snapshot">Hs: -- m · Wind: -- kt</div>
           </div>
         </div>
-        <div id="vessel-info" class="space-y-4"><p class="text-slate-400">Loading vessel data...</p></div>
+        <div id="vessel-info" class="space-y-4 max-h-[320px] overflow-y-auto pr-2"><p class="text-slate-400">Loading vessel data...</p></div>
 
         <div class="grid grid-cols-2 gap-2 mt-4">
           <button id="briefing-btn" class="w-full bg-indigo-600 hover:bg-indigo-700 text-white font-bold py-2 px-3 rounded-lg transition-colors flex items-center justify-center gap-2 text-sm"
@@ -90,6 +93,10 @@
             <div>API 상태 <span class="chip" id="api-status">API: Offline</span></div>
             <button id="api-config-btn" class="px-2 py-1 rounded bg-slate-800/70 hover:bg-slate-700 text-slate-100 border border-slate-600 text-[11px] font-semibold">API 설정</button>
           </div>
+          <label class="flex items-center gap-2 text-[11px] text-slate-300 mt-2">
+            <input type="checkbox" id="opt-mw4-wait" checked class="accent-sky-500" />
+            AGI 대기 금지(출항 지연 전략)
+          </label>
         </div>
         <div class="bg-slate-800/60 border border-slate-700 rounded-lg p-3 text-xs text-slate-200" aria-live="polite">
           <div class="flex items-center justify-between">
@@ -124,6 +131,8 @@
                 <th scope="col" id="th-eta" role="columnheader">ETA</th>
                 <th scope="col" id="th-status" role="columnheader">Status</th>
                 <th scope="col" id="th-ioi" role="columnheader">IOI (0–100)</th>
+                <th scope="col" id="th-sail" role="columnheader">Sail</th>
+                <th scope="col" id="th-discharge" role="columnheader">Discharge</th>
                 <th scope="col" id="th-decision" role="columnheader">Go/No-Go</th>
               </tr>
             </thead>
@@ -212,7 +221,7 @@
 
   document.addEventListener('DOMContentLoaded', () => {
     const apiStorageKey = 'hvdc.apiBaseUrl';
-    const defaultApiBase = window.APP_CONFIG?.apiBase ?? document.body.dataset.apiBaseUrl ?? 'http://localhost:8000';
+    const defaultApiBase = window.APP_CONFIG?.apiBase       ?? document.body.dataset.apiBaseUrl       ?? (window.location.origin?.startsWith('http') ? window.location.origin : 'http://localhost:8002');
     let apiBase = localStorage.getItem(apiStorageKey) || defaultApiBase;
     const apiStatusChip = document.getElementById('api-status');
     const apiConfigBtn = document.getElementById('api-config-btn');
@@ -438,53 +447,67 @@
     }
 
     async function renderSchedule(){
-      const scheduleBody = document.getElementById('schedule-body');
-      if (!scheduleBody) return;
-      
-      document.getElementById('schedule-container').setAttribute('aria-busy','true');
-      scheduleBody.innerHTML = '';
-      
-      const marineSnap = await updateMarineForLeg('Jebel Ali');
-      const baseIoi = Number.isFinite(marineSnap?.ioi) ? Number(marineSnap.ioi) : 50;
+        const scheduleBody = document.getElementById('schedule-body');
+        if (!scheduleBody) return;
 
-      for (let index = 0; index < voyageSchedule.length; index += 1) {
-        const v = voyageSchedule[index];
-        let c="text-slate-300", pill="";
-        if(v.status==="In Transit") { c="text-blue-300"; pill='<span class="tag">Sailing</span>'; }
-        else if(v.status==="Delayed") { c="text-rose-300"; pill='<span class="tag">Delayed</span>'; }
-        else if(v.status==="Completed") { c="text-emerald-300"; pill='<span class="tag">Arrived</span>'; }
-        const hi=v.id===vesselData.currentVoyageId ? "row-current" : "";
+        document.getElementById('schedule-container').setAttribute('aria-busy','true');
+        scheduleBody.innerHTML = '';
 
-        // Marine data for this port (simplified for current structure)
-        const ioi = baseIoi;
-        const decision = ioi >= 75 ? { tag: 'Go', tone: 'success' } :
-                        ioi >= 55 ? { tag: 'Caution', tone: 'warn' } :
-                        { tag: 'No-Go', tone: 'danger' };
-        const formattedIoi = Number.isFinite(ioi) ? Number(ioi).toFixed(2) : '50.00';
+        const marineSnap = await updateMarineForLeg('Jebel Ali');
+        const baseIoi = Number.isFinite(marineSnap?.ioi) ? Number(marineSnap.ioi) : 50;
+        const hasWeatherLevels = weatherWindows.length > 0;
 
-        const row = document.createElement('tr');
-        row.id = `voyage-${v.id}`;
-        row.className = `border-t border-slate-700 ${hi}`;
-        row.setAttribute('role', 'row');
-        row.innerHTML = `
-          <td class="p-2 font-bold" role="gridcell" aria-describedby="th-voyage">${v.id}</td>
-          <td class="p-2" role="gridcell" aria-describedby="th-cargo">${v.cargo}</td>
-          <td class="p-2" role="gridcell" aria-describedby="th-etd">${toLocal(v.etd)}</td>
-          <td class="p-2" role="gridcell" aria-describedby="th-eta">${toLocal(v.eta)}</td>
-          <td class="p-2 ${c} font-semibold" role="gridcell" aria-describedby="th-status">${v.status} ${pill}</td>
-          <td class="p-2" role="gridcell" aria-describedby="th-ioi">${formattedIoi}</td>
-          <td class="p-2" role="gridcell" aria-describedby="th-decision"><span class="pill pill-${decision.tone}">${decision.tag}</span></td>
-        `;
-        scheduleBody.appendChild(row);
+        for (let index = 0; index < voyageSchedule.length; index += 1) {
+          const v = voyageSchedule[index];
+          let c="text-slate-300", pill="";
+          if(v.status==="In Transit") { c="text-blue-300"; pill='<span class="tag">Sailing</span>'; }
+          else if(v.status==="Delayed") { c="text-rose-300"; pill='<span class="tag">Delayed</span>'; }
+          else if(v.status==="Completed") { c="text-emerald-300"; pill='<span class="tag">Arrived</span>'; }
+          const hi=v.id===vesselData.currentVoyageId ? "row-current" : "";
+
+          const etdDate = new Date(v.etd);
+          const etaDate = new Date(v.eta);
+          const spanHours = Math.max(1, Math.round((+etaDate - +etdDate) / 36e5));
+          const spanWidth = clamp((spanHours / 24) * 100, 5, 100).toFixed(2);
+          const gantt = `<div class="gantt-track mt-1" aria-hidden="true"><div class="gantt-fill" style="width:${spanWidth}%"></div></div>`;
+
+          const ioi = Number.isFinite(v.ioi) ? Number(v.ioi) : baseIoi;
+          const decision = ioi >= 75 ? { tag: 'Go', tone: 'success' } :
+                          ioi >= 55 ? { tag: 'Caution', tone: 'warn' } :
+                          { tag: 'No-Go', tone: 'danger' };
+          const formattedIoi = Number.isFinite(ioi) ? ioi.toFixed(2) : baseIoi.toFixed(2);
+
+          const sailLv = hasWeatherLevels ? findSailLevelAt(etdDate) : 'OK';
+          const disLv = hasWeatherLevels ? findDischargeLevelAt(etaDate) : 'OK';
+          const sailBadge = formatLevelBadge(sailLv, hasWeatherLevels);
+          const disBadge = formatLevelBadge(disLv, hasWeatherLevels);
+
+          const row = document.createElement('tr');
+          row.id = `voyage-${v.id}`;
+          row.className = `border-t border-slate-700 ${hi}`;
+          row.setAttribute('role', 'row');
+          row.innerHTML = `
+            <td class="p-2 font-bold" role="gridcell" aria-describedby="th-voyage">${v.id}${gantt}</td>
+            <td class="p-2" role="gridcell" aria-describedby="th-cargo">${v.cargo}</td>
+            <td class="p-2" role="gridcell" aria-describedby="th-etd">${toLocal(v.etd)}</td>
+            <td class="p-2" role="gridcell" aria-describedby="th-eta">${toLocal(v.eta)}</td>
+            <td class="p-2 ${c} font-semibold" role="gridcell" aria-describedby="th-status">${v.status} ${pill}</td>
+            <td class="p-2" role="gridcell" aria-describedby="th-ioi">${formattedIoi}</td>
+            <td class="p-2" role="gridcell" aria-describedby="th-sail">${sailBadge}</td>
+            <td class="p-2" role="gridcell" aria-describedby="th-discharge">${disBadge}</td>
+            <td class="p-2" role="gridcell" aria-describedby="th-decision"><span class="pill pill-${decision.tone}">${decision.tag}</span></td>
+          `;
+          scheduleBody.appendChild(row);
+        }
+
+        document.getElementById('schedule-container').setAttribute('aria-busy','false');
+
+        if(vesselData.currentVoyageId){
+          const row=document.getElementById(`voyage-${vesselData.currentVoyageId}`);
+          if(row) row.scrollIntoView({block:'center',behavior:'smooth'});
+        }
       }
-      
-      document.getElementById('schedule-container').setAttribute('aria-busy','false');
 
-      if(vesselData.currentVoyageId){
-        const row=document.getElementById(`voyage-${vesselData.currentVoyageId}`);
-        if(row) row.scrollIntoView({block:'center',behavior:'smooth'});
-      }
-    }
 
     function setInfo(msgHtml, tone='info'){
       const color = tone==='warn' ? 'bg-yellow-900 border-yellow-500 text-yellow-100'
@@ -493,68 +516,128 @@
       alertContainer.innerHTML = `<div class="${color} px-4 py-3 rounded border">${msgHtml}</div>`;
     }
 
-    const LIM = {
-      waveWarnM: 1.75, waveNoGoM: 2.25,
-      windWarnKt: 24, windNoGoKt: 30,
-      visNoGoKm: 1.0
+    const HOURS_TO_MS = 36e5;
+    const SHIFT_STEP_HOURS = 6;
+    const LIMITS = {
+      sail: {
+        waveWarnM: 1.25,
+        waveNoGoM: 1.75,
+        windWarnKt: 22,
+        windNoGoKt: 28,
+        visNoGoKm: 1.0
+      },
+      discharge: {
+        waveWarnM: 1.00,
+        waveNoGoM: 1.25,
+        windWarnKt: 20,
+        windNoGoKt: 26,
+        visNoGoKm: 1.0
+      }
     };
+
+    function levelByLimits(wv, wd, vs, limset){
+      if(!Number.isFinite(wv) || !Number.isFinite(wd) || !Number.isFinite(vs)) return 'OK';
+      if (wv >= limset.waveNoGoM || wd >= limset.windNoGoKt || vs <= limset.visNoGoKm) return 'NoGo';
+      if (wv >= limset.waveWarnM || wd >= limset.windWarnKt) return 'Warn';
+      return 'OK';
+    }
 
     function buildWeatherWindows(rows){
       weatherWindows = rows.map(r=>{
         const start = parseISO(r.start);
         const end   = parseISO(r.end);
-        const wv = parseNum(r.wave_m);
-        const wd = parseNum(r.wind_kt);
-        const vs = parseNum(r.vis_km);
-        let level = 'None';
-        if(isFinite(wv) && isFinite(wd) && isFinite(vs)){
-          if(wv >= LIM.waveNoGoM || wd >= LIM.windNoGoKt || vs <= LIM.visNoGoKm) level='NoGo';
-          else if(wv >= LIM.waveWarnM || wd >= LIM.windWarnKt) level='Warn';
-        }
-        return { start, end, level, waveM:wv, windKt:wd, visKm:vs };
-      }).filter(w => w.start && w.end);
+        const wv = parseNum(r.wave_m ?? r.waveM ?? r.wave);
+        const wd = parseNum(r.wind_kt ?? r.windKt ?? r.wind);
+        const vs = parseNum(r.vis_km ?? r.visKm ?? r.visibility);
+        if(!start || !end) return null;
+
+        const lvlSail = levelByLimits(wv, wd, vs, LIMITS.sail);
+        const lvlDis  = levelByLimits(wv, wd, vs, LIMITS.discharge);
+
+        return { start, end, level: lvlDis, waveM: wv, windKt: wd, visKm: vs, lvlSail, lvlDis };
+      }).filter(Boolean);
     }
 
-    function findWeatherLevelAt(dt){
+    function findSailLevelAt(dt){
       const t = +dt;
       const w = weatherWindows.find(win => t>= +win.start && t<= +win.end);
-      return w ? w.level : 'None';
+      return w ? w.lvlSail : 'OK';
+    }
+    function findDischargeLevelAt(dt){
+      const t = +dt;
+      const w = weatherWindows.find(win => t>= +win.start && t<= +win.end);
+      return w ? w.lvlDis : 'OK';
     }
 
-    function relHours(a,b){ return ( (+a)-(+b) )/36e5; }
+    function formatLevelBadge(level, hasData){
+      if(!hasData) return '<span class="pill">—</span>';
+      if(level === 'NoGo') return '<span class="pill pill-danger">No-Go</span>';
+      if(level === 'Warn') return '<span class="pill pill-warn">Warn</span>';
+      return '<span class="pill pill-success">OK</span>';
+    }
+
+    function relHours(a,b){ return ((+a)-(+b))/36e5; }
+
+    function hoursToMs(h){ return h * HOURS_TO_MS; }
 
     function applyWeatherToSchedule(){
       if(weatherWindows.length===0){ linkageBadge.textContent='Linked to Weather: OFF'; return; }
       linkageBadge.textContent='Linked to Weather: ON';
 
+      const mw4Wait = document.getElementById('opt-mw4-wait')?.checked ?? true;
       voyageSchedule.sort((x,y)=> +new Date(x.etd) - +new Date(y.etd));
 
       let lastETA = null;
-      let changes = [];
+      const changes = [];
 
       for(let i=0;i<voyageSchedule.length;i++){
         const v = voyageSchedule[i];
         let etd = new Date(v.etd);
         let eta = new Date(v.eta);
+
         if(lastETA && +etd < +lastETA){
           const deltaH = Math.ceil(relHours(lastETA, etd));
-          etd = new Date(+etd + deltaH*36e5);
-          eta = new Date(+eta + deltaH*36e5);
-          changes.push(`${v.id}: shifted +${deltaH}h to keep sequence`);
+          etd = new Date(+etd + hoursToMs(deltaH));
+          eta = new Date(+eta + hoursToMs(deltaH));
+          changes.push(`${v.id}: sequence align +${deltaH}h`);
         }
 
-        const lvlAtETD = findWeatherLevelAt(etd);
-        const lvlAtETA = findWeatherLevelAt(eta);
-
-        if(lvlAtETD==='NoGo'){
-          etd = new Date(+etd + 24*36e5);
-          eta = new Date(+eta + 24*36e5);
-          v.status = 'Delayed';
-          changes.push(`${v.id}: ETD NoGo → +24h`);
-        }else if(lvlAtETA==='NoGo'){
-          eta = new Date(+eta + 12*36e5);
-          v.status = 'Delayed';
-          changes.push(`${v.id}: ETA NoGo → +12h`);
+        if(mw4Wait){
+          let guard = 0;
+          while(guard++ < 200){
+            const sailLv = findSailLevelAt(etd);
+            const disLv = findDischargeLevelAt(eta);
+            if(sailLv === 'NoGo'){
+              etd = new Date(+etd + hoursToMs(SHIFT_STEP_HOURS));
+              eta = new Date(+eta + hoursToMs(SHIFT_STEP_HOURS));
+              continue;
+            }
+            if(disLv !== 'OK'){
+              etd = new Date(+etd + hoursToMs(SHIFT_STEP_HOURS));
+              eta = new Date(+eta + hoursToMs(SHIFT_STEP_HOURS));
+              continue;
+            }
+            break;
+          }
+          if(guard >= 200){
+            changes.push(`${v.id}: weather seek exceeded`);
+          }
+          v.status = 'Scheduled';
+        } else {
+          const sailLv = findSailLevelAt(etd);
+          const disLv = findDischargeLevelAt(eta);
+          if(sailLv === 'NoGo'){
+            etd = new Date(+etd + hoursToMs(24));
+            eta = new Date(+eta + hoursToMs(24));
+            v.status = 'Delayed';
+            changes.push(`${v.id}: ETD No-Go → +24h`);
+          } else if(disLv === 'NoGo'){
+            eta = new Date(+eta + hoursToMs(12));
+            v.status = 'Delayed';
+            changes.push(`${v.id}: ETA No-Go → +12h`);
+          } else if(disLv === 'Warn'){
+            changes.push(`${v.id}: ETA warning — monitor conditions`);
+          }
         }
 
         v.etd = fmtIso(etd);
@@ -569,6 +652,7 @@
       }
       renderSchedule();
     }
+
 
     function chooseActiveVoyage(now){
       return voyageSchedule.find(v => v.status==="In Transit" || ((new Date(v.etd)<=now) && (v.status==="Scheduled" || v.status==="Delayed")));
@@ -717,6 +801,16 @@
       await processWeatherFile(files[0], 'upload');
       weatherInput.value = '';
     });
+
+    const mw4WaitToggle = document.getElementById('opt-mw4-wait');
+    if(mw4WaitToggle){
+      mw4WaitToggle.addEventListener('change', ()=>{
+        if(weatherWindows.length){
+          applyWeatherToSchedule();
+        }
+      });
+    }
+
 
     if(weatherDropTarget){
       ['dragenter','dragover'].forEach(evt=>{
@@ -936,7 +1030,8 @@
         weather_windows: weatherWindows.map(w=>({
           start: w.start ? w.start.toISOString?.() || w.start : w.start,
           end: w.end ? w.end.toISOString?.() || w.end : w.end,
-          level: w.level,
+          sail_level: w.lvlSail,
+          discharge_level: w.lvlDis,
           waveM: w.waveM,
           windKt: w.windKt,
           visKm: w.visKm

--- a/logistics_control_tower_v2.html
+++ b/logistics_control_tower_v2.html
@@ -1,0 +1,796 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Logistics Control Tower v2.5</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" crossorigin=""/>
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" crossorigin=""></script>
+  <style>
+    body{background:#0f172a;color:#e2e8f0;font-family:'Segoe UI',sans-serif}
+    .leaflet-container{background:#1f2937;border-radius:.75rem}
+    .leaflet-tooltip{background:rgba(15,23,42,.95);color:#fff;border:1px solid #475569;box-shadow:none;font-weight:600;padding:4px 8px}
+    .scrollbar-hide::-webkit-scrollbar{display:none}.scrollbar-hide{-ms-overflow-style:none;scrollbar-width:none}
+    .modal{transition:opacity .25s ease;z-index:10000}
+    body.modal-open{overflow:hidden}
+    #map{position:relative;z-index:0}
+    .leaflet-tooltip,.leaflet-popup{z-index:500!important}
+    .row-current{background:rgba(59,130,246,.15)}
+    .kbd{border:1px solid #475569;border-bottom-width:2px;border-radius:.375rem;padding:.15rem .35rem;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+    .tag{font-size:.75rem;padding:.1rem .4rem;border:1px solid #475569;border-radius:.5rem}
+    .chip{display:inline-flex;align-items:center;gap:.25rem;padding:.25rem .5rem;border-radius:.5rem;background:rgba(79,70,229,.2);color:#c7d2fe;font-size:.75rem}
+    .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+    .btn { min-height: 44px; min-width: 44px; } /* 터치 타겟 44px 기준 */
+
+    @media (prefers-contrast: more) {
+        :root {
+            --accent: #00b4ff;
+            --text: #ffffff;
+            --muted: #e2e8f0;
+        }
+        .panel, .status-card, .control-card { border-color: rgba(255,255,255,0.6); }
+        .pill { background: rgba(0,180,255,0.25); }
+    }
+  </style>
+</head>
+<body class="p-4">
+  <!-- Skip link for keyboard users -->
+  <a href="#main" class="sr-only" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;"
+     onfocus="this.style.position='static';this.style.width='auto';this.style.height='auto';this.style.padding='0.5rem 0.75rem';this.style.background='#0ea5e9';this.style.color='#000';this.style.borderRadius='8px';">
+     Skip to main content
+  </a>
+  <main id="main" class="grid grid-cols-1 lg:grid-cols-5 gap-4 h-[95vh]" role="main" aria-live="polite">
+    <div id="map" class="lg:col-span-3 rounded-xl shadow-xl border border-slate-700 h-full min-h-[400px]" 
+         role="img" aria-label="Vessel tracking map showing route from MW4 to AGI" tabindex="0"></div>
+
+    <aside class="lg:col-span-2 flex flex-col gap-4 h-full" role="complementary" aria-label="Vessel control and schedule information">
+      <div id="info-panel" class="bg-slate-900 p-4 rounded-xl shadow-lg border border-slate-700">
+        <div class="flex items-center justify-between">
+          <h2 class="text-xl font-bold border-b border-slate-600 pb-2 mb-3">Vessel Control</h2>
+          <div class="flex items-center gap-2">
+            <span class="tag">Local: Asia/Dubai</span>
+            <div class="pill" id="marineBadge" title="Marine snapshot">Hs: -- m · Wind: -- kt</div>
+          </div>
+        </div>
+        <div id="vessel-info"><p class="text-slate-400">Loading vessel data...</p></div>
+
+        <div class="grid grid-cols-2 gap-2 mt-4">
+          <button id="briefing-btn" class="w-full bg-indigo-600 hover:bg-indigo-700 text-white font-bold py-2 px-3 rounded-lg transition-colors flex items-center justify-center gap-2 text-sm"
+                  aria-describedby="briefing-desc">✨ Daily Briefing</button>
+          <button id="assistant-btn" class="w-full bg-purple-600 hover:bg-purple-700 text-white font-bold py-2 px-3 rounded-lg transition-colors flex items-center justify-center gap-2 text-sm"
+                  aria-describedby="assistant-desc">🤖 Ask AI Assistant</button>
+        </div>
+        <div class="sr-only" id="briefing-desc">Generate AI-powered daily logistics briefing</div>
+        <div class="sr-only" id="assistant-desc">Open AI assistant chat for logistics questions</div>
+
+        <div class="mt-4 grid grid-cols-2 gap-2">
+          <label class="w-full">
+            <input type="file" id="file-schedule" class="hidden" accept=".csv,.json"/>
+            <span id="label-schedule" class="w-full inline-flex items-center justify-center bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-3 rounded-lg cursor-pointer">Upload Schedule (CSV/JSON)</span>
+          </label>
+          <label class="w-full">
+            <input type="file" id="file-weather" class="hidden" accept=".csv"/>
+            <span id="label-weather" class="w-full inline-flex items-center justify-center bg-emerald-600 hover:bg-emerald-700 text-white font-bold py-2 px-3 rounded-lg cursor-pointer">Upload Weather (CSV)</span>
+          </label>
+        </div>
+        <p class="mt-3 text-xs text-slate-400">Tips: Press <span class="kbd">Esc</span> to close modals. 파일 포맷은 하단 가이드를 참고. API는 <span class="chip" id="api-status">API: Offline</span></p>
+      </div>
+
+      <div class="bg-slate-900 p-4 rounded-xl shadow-lg border border-slate-700 flex-grow flex flex-col h-1/2">
+        <div class="flex items-center justify-between border-b border-slate-600 pb-2 mb-3">
+          <h2 class="text-xl font-bold">Full Voyage Schedule</h2>
+          <span id="linkage-badge" class="tag" aria-live="polite">Linked to Weather: OFF</span>
+        </div>
+        <div id="schedule-container" class="overflow-y-auto scrollbar-hide flex-grow" aria-busy="false" role="region" aria-label="Voyage schedule table">
+          <table class="w-full text-left text-sm" role="table" aria-describedby="schedule-caption">
+            <caption id="schedule-caption" class="sr-only">Voyage schedule with ETD, ETA, cargo, and status information</caption>
+            <thead class="sticky top-0 bg-slate-900">
+              <tr role="row">
+                <th scope="col" id="th-voyage" role="columnheader">Voyage</th>
+                <th scope="col" id="th-cargo" role="columnheader">Cargo</th>
+                <th scope="col" id="th-etd" role="columnheader">ETD</th>
+                <th scope="col" id="th-eta" role="columnheader">ETA</th>
+                <th scope="col" id="th-status" role="columnheader">Status</th>
+                <th scope="col" id="th-ioi" role="columnheader">IOI (0–100)</th>
+                <th scope="col" id="th-decision" role="columnheader">Go/No-Go</th>
+              </tr>
+            </thead>
+            <tbody id="schedule-body" role="rowgroup"></tbody>
+          </table>
+        </div>
+      </div>
+
+      <div id="risk-panel" class="bg-slate-900 p-4 rounded-xl shadow-lg border border-slate-700" role="region" aria-label="Risk simulation and control">
+        <div class="flex items-center justify-between">
+          <h2 class="text-xl font-bold border-b border-slate-600 pb-2 mb-3">Risk Simulation & Control</h2>
+          <button id="btn-ai-risk" class="text-xs bg-rose-600 hover:bg-rose-700 text-white px-3 py-1 rounded-md transition"
+                  aria-describedby="risk-scan-desc">AI Risk Scan</button>
+        </div>
+        <div class="flex items-center justify-between gap-3">
+          <p id="sim-time" class="text-lg font-mono" aria-live="polite" aria-label="Current simulation time"></p>
+          <div class="flex items-center gap-2">
+            <button id="btn-reset" class="bg-slate-700 hover:bg-slate-600 text-white text-sm px-3 py-2 rounded"
+                    aria-describedby="reset-desc">Reset Sim</button>
+            <span class="tag" id="sim-speed" aria-live="polite" aria-label="Simulation speed multiplier">×4.00</span>
+          </div>
+        </div>
+        <div id="alert-container" class="mt-4" role="alert" aria-live="polite" aria-atomic="false">
+          <p class="text-green-400">✅ 시스템 정상. 활성 위험 없음.</p>
+        </div>
+        <div class="sr-only" id="risk-scan-desc">Run AI-powered risk analysis on current voyage schedule</div>
+        <div class="sr-only" id="reset-desc">Reset simulation to initial state</div>
+      </div>
+    </div>
+  </div>
+
+  <div id="briefing-modal" class="modal fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center p-4 opacity-0 pointer-events-none"
+       role="dialog" aria-modal="true" aria-labelledby="modal-title" aria-describedby="modal-content" aria-hidden="true">
+    <div class="bg-slate-900 rounded-xl shadow-2xl p-6 w-full max-w-lg border border-slate-700" role="document">
+      <h2 id="modal-title" class="text-2xl font-bold text-indigo-400 mb-4">✨ AI-Generated Output</h2>
+      <div id="modal-content" class="text-slate-300 bg-slate-950 p-4 rounded-md min-h-[150px] whitespace-pre-line overflow-y-auto max-h-[60vh]"></div>
+      <button id="close-modal-btn" class="mt-6 w-full bg-slate-700 hover:bg-slate-600 text-white font-bold py-2 px-4 rounded-lg transition-colors">Close</button>
+    </div>
+  </div>
+
+  <div id="assistant-modal" class="modal fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center p-4 opacity-0 pointer-events-none"
+       role="dialog" aria-modal="true" aria-labelledby="assistant-title" aria-describedby="assistant-conversation" aria-hidden="true">
+    <div class="bg-slate-900 rounded-xl shadow-2xl p-6 w-full max-w-2xl border border-slate-700 flex flex-col h-[80vh]" role="document">
+      <div class="flex items-center justify-between mb-4">
+        <h2 id="assistant-title" class="text-2xl font-bold text-purple-400">🤖 AI Logistics Assistant</h2>
+        <div class="flex items-center gap-2">
+          <label class="text-xs text-slate-300">Model
+            <select id="assistant-model" class="ml-2 bg-slate-800 border border-slate-600 text-slate-100 text-xs rounded px-2 py-1">
+              <option value="gpt-4.1-mini">gpt-4.1-mini</option>
+              <option value="gpt-4o-mini">gpt-4o-mini</option>
+            </select>
+          </label>
+        </div>
+      </div>
+      <div id="assistant-conversation" class="flex-grow bg-slate-950 p-4 rounded-md overflow-y-auto scrollbar-hide space-y-2 text-sm">
+        <div class="text-slate-400">무엇을 도와드릴까요? (예: “다음 3일 스케줄 요약”)<br/>첨부 버튼으로 캡처/문서를 추가하면 자동 분석됩니다.</div>
+      </div>
+      <div class="mt-3 bg-slate-800/60 border border-slate-600 rounded-lg p-3">
+        <div class="flex items-center justify-between">
+          <div class="text-xs text-slate-300 font-semibold">Attachments</div>
+          <button id="assistant-attach-btn" class="text-xs bg-slate-700 hover:bg-slate-600 text-white px-2 py-1 rounded">+ Add</button>
+        </div>
+        <input type="file" id="assistant-file" class="hidden" accept="image/*,.pdf,.txt,.csv" multiple />
+        <div id="assistant-attachments" class="mt-2 text-xs text-slate-400 space-y-1"></div>
+      </div>
+      <form id="assistant-form" class="mt-3 flex gap-2" role="form" aria-label="AI Assistant Chat">
+        <input type="text" id="assistant-input" class="flex-grow bg-slate-800 text-white rounded-lg p-2 border border-slate-600 focus:outline-none focus:ring-2 focus:ring-purple-500" 
+               placeholder="Ask a question..." aria-label="Type your question here" aria-describedby="assistant-input-desc">
+        <button type="submit" class="bg-purple-600 hover:bg-purple-700 text-white font-bold py-2 px-4 rounded-lg transition-colors"
+                aria-label="Send message">Send</button>
+      </form>
+      <div class="sr-only" id="assistant-input-desc">Type your logistics question and press Enter or click Send</div>
+      <div class="flex gap-2 mt-2 text-xs text-slate-400">
+        <button id="assistant-reset" type="button" class="px-3 py-1 rounded bg-slate-700 hover:bg-slate-600 text-white">Clear Chat</button>
+        <span id="assistant-usage" class="italic"></span>
+      </div>
+      <button id="close-assistant-btn" class="mt-3 w-full bg-slate-700 hover:bg-slate-600 text-white font-bold py-2 px-4 rounded-lg transition-colors">Close</button>
+    </div>
+  </div>
+
+  <script>
+    // requestIdleCallback 폴리필 (간단)
+    window.requestIdleCallback ||= (cb)=>setTimeout(()=>cb({didTimeout:false,timeRemaining:()=>0}), 1);
+    window.cancelIdleCallback ||= (id)=>clearTimeout(id);
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const API_BASE = window.APP_CONFIG?.apiBase ?? 'http://localhost:8000';
+    const tz = 'Asia/Dubai';
+    
+    // Scenario presets and port coordinates
+    const scenarioPresets = {
+      base:        { delayOnRisk: 4.0,  hs_caution: 1.50, hs_nogo: 2.50, wind_caution: 18, wind_nogo: 28 },
+      weather:     { delayOnRisk: 6.0,  hs_caution: 1.20, hs_nogo: 2.00, wind_caution: 16, wind_nogo: 24 },
+      congestion:  { delayOnRisk: 5.0,  hs_caution: 1.60, hs_nogo: 2.60, wind_caution: 20, wind_nogo: 30 },
+      inspection:  { delayOnRisk: 3.5, hs_caution: 1.80, hs_nogo: 2.80, wind_caution: 22, wind_nogo: 32 }
+    };
+    const RULE = scenarioPresets.base;
+    
+    const portCoords = {
+      'Shanghai':   { lat: 31.2304, lon: 121.4737 },
+      'Singapore':  { lat: 1.3521,  lon: 103.8198 },
+      'Colombo':    { lat: 6.9271,  lon: 79.8612  },
+      'Jebel Ali':  { lat: 25.006,  lon: 55.065   }
+    };
+    const fmtIso = (d)=> new Date(d).toISOString();
+    const toLocal = (d)=> new Date(d).toLocaleString('en-GB',{ timeZone: tz, dateStyle:'short', timeStyle:'medium' });
+    const pad2 = (n)=> String(n).padStart(2,'0');
+    const clamp = (v,min,max)=> Math.max(min, Math.min(max,v));
+    const parseNum = (s)=> Number(String(s||'').trim());
+    const parseISO = (s)=> {
+      if(!s) return null;
+      const t = String(s).trim().replace(' ', 'T');
+      return isNaN(Date.parse(t)) ? null : new Date(t);
+    };
+    const parseCSV = (text)=>{
+      const lines = text.trim().split(/\r?\n/);
+      const header = lines.shift().split(',').map(h=>h.trim());
+      return lines.map(line=>{
+        const cells = line.split(',').map(c=>c.trim());
+        const obj={};
+        header.forEach((h,i)=> obj[h]=cells[i]);
+        return obj;
+      });
+    };
+
+    async function checkApiHealth(){
+      const badge = document.getElementById('api-status');
+      try{
+        const res = await fetch(`${API_BASE}/health`);
+        if(res.ok){
+          badge.textContent = 'API: Online';
+          badge.classList.remove('bg-rose-500/40');
+          badge.classList.add('bg-emerald-500/40','text-emerald-200');
+        }else{
+          throw new Error('Healthcheck failed');
+        }
+      }catch(err){
+        badge.textContent = 'API: Offline';
+        badge.classList.remove('bg-emerald-500/40','text-emerald-200');
+        badge.classList.add('bg-rose-500/40');
+      }
+    }
+
+    checkApiHealth();
+
+    const map = L.map('map').setView([24.7, 54.1], 8);
+    L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {maxZoom:19, attribution:'&copy; OpenStreetMap & CARTO'}).addTo(map);
+
+    const vesselIcon = L.icon({iconUrl:'https://i.imgur.com/G4Am98f.png', iconSize:[35,35]});
+    const vesselData = {
+      name:"JOPETWIL 71", imo:"9582829", mmsi:"470486000",
+      route:[
+        [24.3400,54.4500], [24.4300,54.4300], [24.4700,54.3900],
+        [24.5600,54.2000], [24.6500,54.0000], [24.8500,53.8000],
+        [24.9500,53.7400], [24.9500,53.3000], [25.0200,53.0600],
+        [24.8400,53.6500]
+      ],
+      marker:L.marker([24.34,54.45],{icon:vesselIcon})
+              .bindTooltip("JOPETWIL 71",{permanent:true,direction:'top',offset:[0,-18],className:'leaflet-tooltip'}),
+      routePolyline:null,
+      progress:0.00,
+      status:"Loading @ MW4",
+      currentVoyageId:null
+    };
+    vesselData.marker.addTo(map);
+    vesselData.routePolyline = L.polyline(vesselData.route, {color:'#FBBF24', weight:3, dashArray:'5,10'}).addTo(map);
+    map.fitBounds(vesselData.routePolyline.getBounds(), {padding:[20,20]});
+
+    let currentSimDate = new Date("2025-09-28T12:00:00Z");
+    let speedFactor = 240;
+    let weatherLinked = false;
+    const simSpeedBadge = document.getElementById('sim-speed');
+    const linkageBadge = document.getElementById('linkage-badge');
+    simSpeedBadge.textContent = '×4.00';
+
+    let voyageSchedule = [
+      { id:"69th", cargo:"Dune Sand",  etd:"2025-09-28T16:00:00Z", eta:"2025-09-29T04:00:00Z", status:"Scheduled" },
+      { id:"70th", cargo:"10mm Agg.",  etd:"2025-09-30T16:00:00Z", eta:"2025-10-01T04:00:00Z", status:"Scheduled" },
+      { id:"71st", cargo:"5mm Agg.",   etd:"2025-10-02T16:00:00Z", eta:"2025-10-03T04:00:00Z", status:"Scheduled" }
+    ];
+
+    let weatherWindows = [];
+
+    const R=6371e3, toRad=d=>d*Math.PI/180;
+    function haversine(a,b){
+      const [lat1,lon1]=a,[lat2,lon2]=b;
+      const dLat=toRad(lat2-lat1), dLon=toRad(lon2-lon1);
+      const phi1=toRad(lat1), phi2=toRad(lat2);
+      const h=Math.sin(dLat/2)**2 + Math.cos(phi1)*Math.cos(phi2)*Math.sin(dLon/2)**2;
+      return 2*R*Math.asin(Math.sqrt(h));
+    }
+    const segments=[]; let totalMeters=0;
+    for(let i=0;i<vesselData.route.length-1;i++){
+      const a=vesselData.route[i], b=vesselData.route[i+1];
+      const m=haversine(a,b);
+      segments.push({a,b,m,accStart:totalMeters,accEnd:totalMeters+m});
+      totalMeters+=m;
+    }
+    function interpolateOnRoute(progress){
+      const target=clamp(progress,0,1)*totalMeters;
+      const seg=segments.find(s=>target>=s.accStart && target<=s.accEnd) || segments[segments.length-1];
+      const t=(target-seg.accStart)/(seg.m||1);
+      const lat=seg.a[0]+(seg.b[0]-seg.a[0])*t;
+      const lon=seg.a[1]+(seg.b[1]-seg.a[1])*t;
+      return [Number(lat.toFixed(5)), Number(lon.toFixed(5))];
+    }
+
+    const infoPanel = document.getElementById('vessel-info');
+    const timeDisplay = document.getElementById('sim-time');
+    const scheduleContainer = document.getElementById('schedule-container');
+    const alertContainer = document.getElementById('alert-container');
+    const assistantConversation = document.getElementById('assistant-conversation');
+    const assistantUsage = document.getElementById('assistant-usage');
+    const assistantFileInput = document.getElementById('assistant-file');
+    const assistantAttachments = document.getElementById('assistant-attachments');
+    const assistantModelSelect = document.getElementById('assistant-model');
+    let assistantHistory = [];
+    let pendingAttachments = [];
+
+    function updateInfoPanel(){
+      const cur=vesselData.currentVoyageId||'N/A';
+      infoPanel.innerHTML =
+        `<h3 class="text-2xl font-bold text-cyan-400">${vesselData.name}</h3>
+         <p class="text-sm text-slate-400">IMO: ${vesselData.imo} / MMSI: ${vesselData.mmsi}</p>
+         <div class="mt-4 space-y-2">
+           <div><strong>Current Voyage:</strong> <span class="font-mono text-lg">${cur}</span></div>
+           <div><strong>Status:</strong> <span class="font-mono text-lg text-yellow-300">${vesselData.status}</span></div>
+         </div>`;
+    }
+
+    async function renderSchedule(){
+      const scheduleBody = document.getElementById('schedule-body');
+      if (!scheduleBody) return;
+      
+      document.getElementById('schedule-container').setAttribute('aria-busy','true');
+      scheduleBody.innerHTML = '';
+      
+      for (let index = 0; index < voyageSchedule.length; index += 1) {
+        const v = voyageSchedule[index];
+        let c="text-slate-300", pill="";
+        if(v.status==="In Transit") { c="text-blue-300"; pill='<span class="tag">Sailing</span>'; }
+        else if(v.status==="Delayed") { c="text-rose-300"; pill='<span class="tag">Delayed</span>'; }
+        else if(v.status==="Completed") { c="text-emerald-300"; pill='<span class="tag">Arrived</span>'; }
+        const hi=v.id===vesselData.currentVoyageId ? "row-current" : "";
+        
+        // Marine data for this port (simplified for current structure)
+        const snap = await updateMarineForLeg('Jebel Ali'); // Default port for now
+        const ioi = snap?.ioi ?? 50;
+        const decision = ioi >= 75 ? { tag: 'Go', tone: 'success' } : 
+                        ioi >= 55 ? { tag: 'Caution', tone: 'warn' } : 
+                        { tag: 'No-Go', tone: 'danger' };
+        
+        const row = document.createElement('tr');
+        row.id = `voyage-${v.id}`;
+        row.className = `border-t border-slate-700 ${hi}`;
+        row.setAttribute('role', 'row');
+        row.innerHTML = `
+          <td class="p-2 font-bold" role="gridcell" aria-describedby="th-voyage">${v.id}</td>
+          <td class="p-2" role="gridcell" aria-describedby="th-cargo">${v.cargo}</td>
+          <td class="p-2" role="gridcell" aria-describedby="th-etd">${toLocal(v.etd)}</td>
+          <td class="p-2" role="gridcell" aria-describedby="th-eta">${toLocal(v.eta)}</td>
+          <td class="p-2 ${c} font-semibold" role="gridcell" aria-describedby="th-status">${v.status} ${pill}</td>
+          <td class="p-2" role="gridcell" aria-describedby="th-ioi">${ioi}</td>
+          <td class="p-2" role="gridcell" aria-describedby="th-decision"><span class="pill ${decision.tone === 'danger' ? 'danger' : ''}">${decision.tag}</span></td>
+        `;
+        scheduleBody.appendChild(row);
+      }
+      
+      document.getElementById('schedule-container').setAttribute('aria-busy','false');
+
+      if(vesselData.currentVoyageId){
+        const row=document.getElementById(`voyage-${vesselData.currentVoyageId}`);
+        if(row) row.scrollIntoView({block:'center',behavior:'smooth'});
+      }
+    }
+
+    function setInfo(msgHtml, tone='info'){
+      const color = tone==='warn' ? 'bg-yellow-900 border-yellow-500 text-yellow-100'
+                   : tone==='danger' ? 'bg-rose-900 border-rose-500 text-rose-100'
+                   : 'bg-slate-950 border-slate-600 text-slate-200';
+      alertContainer.innerHTML = `<div class="${color} px-4 py-3 rounded border">${msgHtml}</div>`;
+    }
+
+    const LIM = {
+      waveWarnM: 1.75, waveNoGoM: 2.25,
+      windWarnKt: 24, windNoGoKt: 30,
+      visNoGoKm: 1.0
+    };
+
+    function buildWeatherWindows(rows){
+      weatherWindows = rows.map(r=>{
+        const start = parseISO(r.start);
+        const end   = parseISO(r.end);
+        const wv = parseNum(r.wave_m);
+        const wd = parseNum(r.wind_kt);
+        const vs = parseNum(r.vis_km);
+        let level = 'None';
+        if(isFinite(wv) && isFinite(wd) && isFinite(vs)){
+          if(wv >= LIM.waveNoGoM || wd >= LIM.windNoGoKt || vs <= LIM.visNoGoKm) level='NoGo';
+          else if(wv >= LIM.waveWarnM || wd >= LIM.windWarnKt) level='Warn';
+        }
+        return { start, end, level, waveM:wv, windKt:wd, visKm:vs };
+      }).filter(w => w.start && w.end);
+    }
+
+    function findWeatherLevelAt(dt){
+      const t = +dt;
+      const w = weatherWindows.find(win => t>= +win.start && t<= +win.end);
+      return w ? w.level : 'None';
+    }
+
+    function relHours(a,b){ return ( (+a)-(+b) )/36e5; }
+
+    function applyWeatherToSchedule(){
+      if(weatherWindows.length===0){ linkageBadge.textContent='Linked to Weather: OFF'; return; }
+      linkageBadge.textContent='Linked to Weather: ON';
+
+      voyageSchedule.sort((x,y)=> +new Date(x.etd) - +new Date(y.etd));
+
+      let lastETA = null;
+      let changes = [];
+
+      for(let i=0;i<voyageSchedule.length;i++){
+        const v = voyageSchedule[i];
+        let etd = new Date(v.etd);
+        let eta = new Date(v.eta);
+        if(lastETA && +etd < +lastETA){
+          const deltaH = Math.ceil(relHours(lastETA, etd));
+          etd = new Date(+etd + deltaH*36e5);
+          eta = new Date(+eta + deltaH*36e5);
+          changes.push(`${v.id}: shifted +${deltaH}h to keep sequence`);
+        }
+
+        const lvlAtETD = findWeatherLevelAt(etd);
+        const lvlAtETA = findWeatherLevelAt(eta);
+
+        if(lvlAtETD==='NoGo'){
+          etd = new Date(+etd + 24*36e5);
+          eta = new Date(+eta + 24*36e5);
+          v.status = 'Delayed';
+          changes.push(`${v.id}: ETD NoGo → +24h`);
+        }else if(lvlAtETA==='NoGo'){
+          eta = new Date(+eta + 12*36e5);
+          v.status = 'Delayed';
+          changes.push(`${v.id}: ETA NoGo → +12h`);
+        }
+
+        v.etd = fmtIso(etd);
+        v.eta = fmtIso(eta);
+        lastETA = eta;
+      }
+
+      if(changes.length){
+        setInfo(`<strong>Weather linked.</strong><br>${changes.map(c=>`• ${c}`).join('<br>')}`, 'warn');
+      }else{
+        setInfo('날씨 연동됨. 변경 사항 없음.');
+      }
+      renderSchedule();
+    }
+
+    function chooseActiveVoyage(now){
+      return voyageSchedule.find(v => v.status==="In Transit" || ((new Date(v.etd)<=now) && (v.status==="Scheduled" || v.status==="Delayed")));
+    }
+
+    function runSimulation(){
+      currentSimDate.setMinutes(currentSimDate.getMinutes() + (1 * speedFactor / 60));
+      timeDisplay.textContent = toLocal(currentSimDate);
+
+      let active = chooseActiveVoyage(currentSimDate);
+      if(active && vesselData.currentVoyageId!==active.id){
+        vesselData.currentVoyageId=active.id; vesselData.progress=0.00;
+      }
+
+      if(active){
+        const etd=new Date(active.etd), eta=new Date(active.eta);
+        const total=eta-etd;
+        if(currentSimDate>=etd && currentSimDate<=eta){
+          if(active.status!=="Delayed") active.status="In Transit";
+          vesselData.status = active.status==="Delayed" ? "In Transit (Delayed)" : "In Transit to AGI";
+          vesselData.progress=(currentSimDate-etd)/total;
+          const [lat,lon]=interpolateOnRoute(vesselData.progress);
+          vesselData.marker.setLatLng([lat,lon]);
+        }else if(currentSimDate>eta){
+          if(active.status!=="Completed"){
+            active.status="Completed";
+            vesselData.marker.setLatLng(vesselData.route[vesselData.route.length-1]);
+            vesselData.status="Discharging @ AGI";
+            setTimeout(()=>{
+              vesselData.marker.setLatLng(vesselData.route[0]);
+              vesselData.status="Ready for Loading @ MW4";
+              updateInfoPanel();
+            }, 4000);
+          }
+        }
+      }
+
+      updateInfoPanel();
+      renderSchedule();
+    }
+
+    const scheduleInput = document.getElementById('file-schedule');
+    const weatherInput  = document.getElementById('file-weather');
+    const scheduleLabel = document.getElementById('label-schedule');
+    const weatherLabel  = document.getElementById('label-weather');
+
+    scheduleLabel.addEventListener('click',()=> scheduleInput.click());
+    weatherLabel.addEventListener('click',()=> weatherInput.click());
+
+    scheduleInput.addEventListener('change', (e)=>{
+      if(e.target.files.length===0) return;
+      const f = e.target.files[0];
+      const reader = new FileReader();
+      reader.onload = () => {
+        try{
+          let rows;
+          if(f.name.toLowerCase().endsWith('.json')){
+            const data = JSON.parse(reader.result);
+            if(!Array.isArray(data)) throw new Error('JSON must be an array');
+            rows = data;
+          } else {
+            rows = parseCSV(reader.result);
+          }
+          const normalized = rows.map(r=>{
+            const id = r.id || r.Voyage || r.voyage || r.trip || '';
+            const cargo = r.cargo || r.Cargo || '';
+            const etd = r.etd || r.ETD || r.departure || '';
+            const eta = r.eta || r.ETA || r.arrival || '';
+            const status = r.status || r.Status || 'Scheduled';
+            const etdDt = parseISO(etd), etaDt = parseISO(eta);
+            if(!id || !cargo || !etdDt || !etaDt) throw new Error('Missing required fields (id,cargo,etd,eta)');
+            return { id:String(id).trim(), cargo:String(cargo).trim(), etd:fmtIso(etdDt), eta:fmtIso(etaDt), status:String(status).trim() };
+          });
+          voyageSchedule = normalized.sort((a,b)=> +new Date(a.etd)-+new Date(b.etd));
+          scheduleLabel.textContent = `Loaded: ${f.name}`;
+          setInfo(`스케줄 ${normalized.length}건 로드 완료.`, 'info');
+          renderSchedule();
+        }catch(err){
+          console.error(err);
+          setInfo(`⚠️ 스케줄 파일 오류: ${err.message}`, 'danger');
+        }
+      };
+      reader.readAsText(f);
+    });
+
+    weatherInput.addEventListener('change', (e)=>{
+      if(e.target.files.length===0) return;
+      const f = e.target.files[0];
+      const reader = new FileReader();
+      reader.onload = ()=>{
+        try{
+          const rows = parseCSV(reader.result);
+          buildWeatherWindows(rows);
+          weatherLabel.textContent = `Loaded: ${f.name}`;
+          weatherLinked = true;
+          applyWeatherToSchedule();
+        }catch(err){
+          console.error(err);
+          setInfo(`⚠️ 날씨 파일 오류: ${err.message}`, 'danger');
+        }
+      };
+      reader.readAsText(f);
+    });
+
+    const briefingModal=document.getElementById('briefing-modal');
+    const assistantModal=document.getElementById('assistant-modal');
+    const modalTitle=document.getElementById('modal-title');
+    const modalContent=document.getElementById('modal-content');
+
+    function openModal(el){ 
+      el.classList.remove('opacity-0','pointer-events-none'); 
+      el.setAttribute('aria-hidden', 'false');
+      document.body.classList.add('modal-open'); 
+      // Focus management
+      const focusableElements = el.querySelectorAll('button, input, select, textarea, [tabindex]:not([tabindex="-1"])');
+      if(focusableElements.length > 0) {
+        focusableElements[0].focus();
+      }
+    }
+    function closeModal(el){ 
+      el.classList.add('opacity-0','pointer-events-none'); 
+      el.setAttribute('aria-hidden', 'true');
+      document.body.classList.remove('modal-open'); 
+    }
+    [briefingModal,assistantModal].forEach(m=> m.addEventListener('click', e=>{ if(e.target===m) closeModal(m); }));
+    document.addEventListener('keydown', e=>{ if(e.key==='Escape'){ [briefingModal,assistantModal].forEach(closeModal); } });
+
+    function renderAttachmentList(){
+      if(pendingAttachments.length===0){
+        assistantAttachments.innerHTML = '<div class="text-slate-500">No attachments selected.</div>';
+        return;
+      }
+      assistantAttachments.innerHTML = pendingAttachments.map((file,idx)=>{
+        return `<div class="flex justify-between items-center bg-slate-900/80 px-2 py-1 rounded">
+                  <span class="truncate max-w-[14rem]">${file.name}</span>
+                  <button data-index="${idx}" class="text-rose-300 hover:text-rose-400 remove-attachment">Remove</button>
+                </div>`;
+      }).join('');
+      assistantAttachments.querySelectorAll('.remove-attachment').forEach(btn=>{
+        btn.addEventListener('click',(ev)=>{
+          const idx = Number(ev.target.getAttribute('data-index'));
+          pendingAttachments.splice(idx,1);
+          renderAttachmentList();
+        });
+      });
+    }
+
+    assistantAttachments.innerHTML = '<div class="text-slate-500">No attachments selected.</div>';
+
+    document.getElementById('assistant-attach-btn').addEventListener('click', ()=> assistantFileInput.click());
+    assistantFileInput.addEventListener('change', (event)=>{
+      pendingAttachments = Array.from(event.target.files || []);
+      renderAttachmentList();
+    });
+
+    document.getElementById('assistant-reset').addEventListener('click', ()=>{
+      assistantHistory = [];
+      assistantConversation.innerHTML = '<div class="text-slate-400">무엇을 도와드릴까요? (예: “다음 3일 스케줄 요약”)</div>';
+      assistantUsage.textContent='';
+    });
+
+    async function callAssistant(prompt, attachments){
+      const formData = new FormData();
+      formData.append('prompt', prompt);
+      formData.append('history', JSON.stringify(assistantHistory));
+      formData.append('model', assistantModelSelect.value);
+      attachments.forEach(file=> formData.append('files', file, file.name));
+      const res = await fetch(`${API_BASE}/api/assistant`, { method:'POST', body: formData });
+      if(!res.ok){
+        const text = await res.text();
+        throw new Error(text || 'Assistant call failed');
+      }
+      const data = await res.json();
+      assistantHistory.push({role:'user', content: prompt});
+      assistantHistory.push({role:'assistant', content: data.answer});
+      assistantUsage.textContent = `Last response model: ${assistantModelSelect.value}`;
+      return data.answer;
+    }
+
+    async function fetchBriefing(){
+      modalTitle.textContent = '✨ Daily Briefing';
+      modalContent.innerHTML = '생성 중...';
+      openModal(briefingModal);
+      const payload = {
+        current_time: currentSimDate.toISOString(),
+        vessel_name: vesselData.name,
+        vessel_status: vesselData.status,
+        current_voyage: vesselData.currentVoyageId,
+        schedule: voyageSchedule,
+        weather_windows: weatherWindows.map(w=>({
+          start: w.start ? w.start.toISOString?.() || w.start : w.start,
+          end: w.end ? w.end.toISOString?.() || w.end : w.end,
+          level: w.level,
+          waveM: w.waveM,
+          windKt: w.windKt,
+          visKm: w.visKm
+        }))
+      };
+      try{
+        const res = await fetch(`${API_BASE}/api/briefing`, {
+          method:'POST',
+          headers:{'Content-Type':'application/json'},
+          body: JSON.stringify(payload)
+        });
+        if(!res.ok) throw new Error(await res.text());
+        const data = await res.json();
+        modalContent.innerHTML = data.briefing.replace(/\n/g,'<br>');
+      }catch(err){
+        console.error(err);
+        const cur = voyageSchedule.find(v=>v.id===vesselData.currentVoyageId);
+        const fallback = `현재 시각 ${toLocal(currentSimDate)}.\n진행 항차: ${cur?.id || 'N/A'} / 화물: ${cur?.cargo || 'N/A'} / 상태: ${vesselData.status}.`;
+        modalContent.innerHTML = `${fallback.replace(/\n/g,'<br>')}<br><br><span class="text-rose-300">AI Briefing unavailable: ${err.message}</span>`;
+      }
+    }
+
+    async function runRiskScan(){
+      const prompt = `다음 일정과 기상창을 기반으로 3가지 위험 시나리오와 대응 권고를 bullet로 정리해줘.\n일정: ${JSON.stringify(voyageSchedule)}\n기상: ${JSON.stringify(weatherWindows)}`;
+      setInfo('AI 위험 스캔 실행 중...', 'info');
+      try{
+        const answer = await callAssistant(prompt, []);
+        setInfo(answer.replace(/\n/g,'<br>'), 'warn');
+      }catch(err){
+        setInfo(`AI 위험 스캔 실패: ${err.message}`, 'danger');
+      }
+    }
+
+    document.getElementById('briefing-btn').addEventListener('click', fetchBriefing);
+    document.getElementById('btn-ai-risk').addEventListener('click', runRiskScan);
+    document.getElementById('close-modal-btn').addEventListener('click', ()=>closeModal(briefingModal));
+    document.getElementById('assistant-btn').addEventListener('click', ()=>openModal(assistantModal));
+    document.getElementById('close-assistant-btn').addEventListener('click', ()=>closeModal(assistantModal));
+
+    document.getElementById('assistant-form').addEventListener('submit', async (e)=>{
+      e.preventDefault();
+      const input=document.getElementById('assistant-input');
+      const q=input.value.trim(); if(!q) return;
+      assistantConversation.innerHTML += `<div class="text-right"><span class="bg-purple-800/80 p-2 rounded-lg inline-block">${q}</span></div>`;
+      input.value='';
+      assistantConversation.scrollTop=assistantConversation.scrollHeight;
+      try{
+        const ans = await callAssistant(q, pendingAttachments);
+        assistantConversation.innerHTML += `<div class="text-left"><span class="bg-slate-800 p-2 rounded-lg inline-block">${ans.replace(/\n/g,'<br>')}</span></div>`;
+        assistantConversation.scrollTop=assistantConversation.scrollHeight;
+        pendingAttachments = [];
+        assistantFileInput.value = '';
+        renderAttachmentList();
+      }catch(err){
+        assistantConversation.innerHTML += `<div class="text-left text-rose-300">${err.message}</div>`;
+        assistantConversation.scrollTop=assistantConversation.scrollHeight;
+      }
+    });
+
+    document.getElementById('btn-reset').addEventListener('click', ()=>{
+      currentSimDate = new Date("2025-09-28T12:00:00Z");
+      vesselData.currentVoyageId = null;
+      vesselData.status = "Ready @ MW4";
+      setInfo('시뮬레이션 시계가 초기화되었습니다.');
+    });
+
+    // Marine data functions
+    async function updateMarineForLeg(portName) {
+      // 워커로 오프로드
+      const snap = await fetchMarineAndIOIInWorker(portName);
+      if (snap && snap.hs != null && snap.windKt != null) {
+        marineBadge.textContent = `Hs: ${snap.hs.toFixed(2)} m · Wind: ${Math.round(snap.windKt)} kt`;
+      } else {
+        marineBadge.textContent = `Marine: n/a`;
+      }
+      return snap;
+    }
+
+    // ===== Worker 생성 (Blob URL) : IOI 계산 + Marine fetch 오프로드 =====
+    const workerCode = `
+      self.addEventListener('message', async (e) => {
+        const { type, payload } = e.data || {};
+        if (type === 'marine+ioi') {
+          const { port, coords, RULE } = payload;
+          try {
+            const params = new URLSearchParams({
+              latitude: String(coords.lat),
+              longitude: String(coords.lon),
+              hourly: ['wave_height','wind_speed_10m','swell_wave_period'].join(','),
+              timezone: 'auto'
+            });
+            const url = 'https://marine-api.open-meteo.com/v1/marine?' + params.toString();
+            const r = await fetch(url);
+            const j = await r.json();
+            const idx = 0;
+            const hs = j?.hourly?.wave_height?.[idx] ?? null;
+            const wsms = j?.hourly?.wind_speed_10m?.[idx] ?? null;
+            const sp = j?.hourly?.swell_wave_period?.[idx] ?? null;
+            const windKt = wsms != null ? (wsms * 1.94384) : null;
+            // IOI 계산 (워커쪽 동일 로직)
+            function ioiCalc(hs, windKt, sp, RULE){
+              const hsScore = (hs==null)?0.5:(hs<=RULE.hs_caution?1:hs>=RULE.hs_nogo?0:1-((hs-RULE.hs_caution)/(RULE.hs_nogo-RULE.hs_caution)));
+              const wScore  = (windKt==null)?0.5:(windKt<=RULE.wind_caution?1:windKt>=RULE.wind_nogo?0:1-((windKt-RULE.wind_caution)/(RULE.wind_nogo-RULE.wind_caution)));
+              const spMin=6, spMax=12; const s = Math.max(spMin, Math.min(spMax, (sp ?? 8)));
+              const swellScore = (s-spMin)/(spMax-spMin);
+              const score = 0.5*hsScore + 0.35*wScore + 0.15*swellScore;
+              return Math.round(score*100);
+            }
+            const ioi = ioiCalc(hs, windKt, sp, RULE);
+            self.postMessage({ type:'marine+ioi:done', payload:{ port, hs, windKt, sp, ioi }});
+          } catch (err) {
+            self.postMessage({ type:'marine+ioi:error', payload:{ port, error: String(err) }});
+          }
+        }
+      });
+    `;
+    const workerUrl = URL.createObjectURL(new Blob([workerCode], {type:'text/javascript'}));
+    const marineWorker = new Worker(workerUrl, { type:'module' });
+    const pendingIOI = new Map(); // port -> Promise resolvers
+    marineWorker.addEventListener('message', (e)=>{
+      const { type, payload } = e.data || {};
+      if (type === 'marine+ioi:done') {
+        const { port, hs, windKt, sp, ioi } = payload;
+        const resolver = pendingIOI.get(port);
+        if (resolver) { resolver.resolve({ hs, windKt, swellPeriod: sp, ioi }); pendingIOI.delete(port); }
+      } else if (type === 'marine+ioi:error') {
+        const resolver = pendingIOI.get(payload.port);
+        if (resolver) { resolver.resolve(null); pendingIOI.delete(payload.port); }
+      }
+    });
+    function fetchMarineAndIOIInWorker(portName) {
+      const coords = portCoords[portName];
+      if (!coords) return Promise.resolve(null);
+      return new Promise((resolve)=> {
+        pendingIOI.set(portName, { resolve });
+        marineWorker.postMessage({ type:'marine+ioi', payload: { port: portName, coords, RULE }});
+      });
+    }
+
+    // Passive listeners (스크롤/터치)
+    window.addEventListener('scroll', ()=>{}, { passive:true });
+    window.addEventListener('touchstart', ()=>{}, { passive:true });
+
+    setInterval(runSimulation, 50);
+    runSimulation();
+  });
+  </script>
+</body>
+</html>

--- a/openai_gateway.py
+++ b/openai_gateway.py
@@ -7,15 +7,14 @@ import io
 import json
 import logging
 import os
-from typing import Iterable, List, Literal, Sequence
+from pathlib import Path
+from typing import Any, Iterable, List, Literal, Sequence
 
 from fastapi import FastAPI, File, Form, HTTPException, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from openai import AsyncOpenAI
-from openai.types.chat import ChatCompletion
 from pydantic import BaseModel, ConfigDict, Field
 from PyPDF2 import PdfReader
-
 
 LOGGER = logging.getLogger(__name__)
 
@@ -42,6 +41,7 @@ class BriefingRequest(LogiBaseModel):
     current_voyage: str | None = None
     schedule: List[dict] = Field(default_factory=list)
     weather_windows: List[dict] = Field(default_factory=list)
+    model: str = Field(default="gpt-4.1-mini", max_length=64)
 
 
 class BriefingResponse(LogiBaseModel):
@@ -57,14 +57,47 @@ class AssistantResponse(LogiBaseModel):
 
 
 _async_client: AsyncOpenAI | None = None
+_dotenv_loaded = False
+
+
+def _load_dotenv() -> None:
+    """로컬 .env 파일에서 환경변수를 로드. | Load environment variables from .env."""
+
+    global _dotenv_loaded
+    if _dotenv_loaded:
+        return
+
+    candidates = [
+        Path.cwd() / ".env",
+        Path(__file__).resolve().parent / ".env",
+    ]
+    for env_path in candidates:
+        if not env_path.exists():
+            continue
+        try:
+            with env_path.open("r", encoding="utf-8") as handle:
+                for raw_line in handle:
+                    line = raw_line.strip()
+                    if not line or line.startswith("#") or "=" not in line:
+                        continue
+                    key, value = line.split("=", maxsplit=1)
+                    key = key.strip()
+                    value = value.strip().strip('"').strip("'")
+                    if key and key not in os.environ:
+                        os.environ[key] = value
+        except OSError as exc:  # pragma: no cover - filesystem edge
+            LOGGER.warning("Failed to load .env file %s: %s", env_path, exc)
+    _dotenv_loaded = True
 
 
 def _require_client() -> AsyncOpenAI:
     """OpenAI 클라이언트를 생성. | Build an OpenAI client."""
 
+    _load_dotenv()
     api_key = os.getenv("OPENAI_API_KEY")
     if not api_key:
-        raise HTTPException(status_code=500, detail="OPENAI_API_KEY is not configured")
+        error_message = "OPENAI_API_KEY is not configured"
+        raise HTTPException(status_code=500, detail=error_message)
     global _async_client
     if _async_client is None:
         _async_client = AsyncOpenAI(api_key=api_key)
@@ -85,35 +118,78 @@ def _pdf_to_text(payload: bytes) -> str:
 def _image_to_base64(file: UploadFile, payload: bytes) -> dict:
     """이미지를 base64로 인코딩. | Encode image to base64."""
 
-    data_url = f"data:{file.content_type};base64,{base64.b64encode(payload).decode('utf-8')}"
-    return {"type": "input_image", "image_url": data_url}
+    data_url = "data:{media};base64,{payload}".format(
+        media=file.content_type,
+        payload=base64.b64encode(payload).decode("utf-8"),
+    )
+    return {"type": "input_image", "image_url": {"url": data_url}}
 
 
-def _build_user_content(prompt: str, files: Iterable[UploadFile], raw_payloads: List[bytes]) -> str:
+def _build_user_content(
+    prompt: str, files: Iterable[UploadFile], raw_payloads: List[bytes]
+) -> List[dict[str, Any]]:
     """사용자 메시지 콘텐츠 구성. | Compose user content payload."""
 
-    content_parts = [prompt]
+    content: List[dict[str, Any]] = [{"type": "text", "text": prompt}]
     for idx, file in enumerate(files):
         data = raw_payloads[idx]
+        filename = file.filename or f"attachment-{idx+1}"
         if file.content_type and file.content_type.startswith("image/"):
-            # For images, we'll include a reference in the text
-            content_parts.append(f"\n[첨부 이미지: {file.filename}]")
-        elif (file.content_type == "application/pdf") or file.filename.lower().endswith(".pdf"):
+            content.append(
+                {
+                    "type": "text",
+                    "text": f"[이미지 첨부: {filename}]",
+                }
+            )
+            content.append(_image_to_base64(file, data))
+            continue
+
+        is_pdf_content = file.content_type == "application/pdf"
+        if is_pdf_content or filename.lower().endswith(".pdf"):
             pdf_text = _pdf_to_text(data)[:8000]
-            descriptor = f"\n[첨부 PDF: {file.filename}]\n"
-            content_parts.append(descriptor + pdf_text)
-        else:
-            try:
-                decoded = data.decode("utf-8")
-            except UnicodeDecodeError:
-                decoded = base64.b64encode(data).decode("utf-8")
-                decoded = f"[base64-encoded attachment]\n{decoded[:6000]}"
-            content_parts.append(f"\n[첨부 파일: {file.filename}]\n{decoded[:8000]}")
-    return "\n".join(content_parts)
+            descriptor = f"[PDF 첨부: {filename}]\n{pdf_text}"
+            content.append(
+                {
+                    "type": "text",
+                    "text": descriptor,
+                }
+            )
+            continue
+
+        try:
+            decoded = data.decode("utf-8")
+        except UnicodeDecodeError:
+            decoded = base64.b64encode(data).decode("utf-8")
+            decoded = f"[base64-encoded attachment]\n{decoded[:6000]}"
+        content.append(
+            {
+                "type": "text",
+                "text": f"[파일 첨부: {filename}]\n{decoded[:8000]}",
+            }
+        )
+
+    return content
 
 
-def _extract_output_text(response: ChatCompletion) -> str:
+def _extract_output_text(response: Any) -> str:
     """Chat Completion 결과에서 텍스트 추출. | Extract text from Chat Completion."""
+
+    outputs = getattr(response, "output", None)
+    if outputs:
+        texts: List[str] = []
+        for item in outputs:
+            if getattr(item, "type", None) != "message":
+                continue
+            message = getattr(item, "message", None)
+            if not message:
+                continue
+            for block in getattr(message, "content", []) or []:
+                if getattr(block, "type", None) == "text":
+                    text_value = getattr(block, "text", "")
+                    if text_value:
+                        texts.append(text_value)
+        if texts:
+            return "\n".join(texts)
 
     try:
         return response.choices[0].message.content
@@ -121,22 +197,26 @@ def _extract_output_text(response: ChatCompletion) -> str:
         return "Error: Could not extract response text"
 
 
-async def _call_openai(messages: List[dict], *, model: str) -> ChatCompletion:
+async def _call_openai(messages: List[dict[str, Any]], *, model: str) -> Any:
     """OpenAI Responses API 호출. | Invoke OpenAI Responses API."""
 
     client = _require_client()
-    return await client.chat.completions.create(model=model, messages=messages)
+    return await client.responses.create(model=model, input=messages)
 
 
-def _build_history(messages: Sequence[ChatMessage]) -> List[dict]:
+def _build_history(messages: Sequence[ChatMessage]) -> List[dict[str, Any]]:
     """Chat Completion용 메시지 배열 구성. | Build chat completion messages."""
 
-    history: List[dict] = []
+    history: List[dict[str, Any]] = []
     for item in messages:
-        history.append({
-            "role": item.role,
-            "content": item.content
-        })
+        history.append(
+            {
+                "role": item.role,
+                "content": [
+                    {"type": "text", "text": item.content},
+                ],
+            }
+        )
     return history
 
 
@@ -168,9 +248,17 @@ async def run_assistant(
 
     try:
         raw_history = json.loads(history)
-        history_messages = [ChatMessage.model_validate(item) for item in raw_history]
-    except (json.JSONDecodeError, TypeError, ValueError) as exc:  # pragma: no cover - validation
-        raise HTTPException(status_code=400, detail=f"Invalid history payload: {exc}") from exc
+        history_messages: List[ChatMessage] = []
+        for item in raw_history:
+            history_messages.append(ChatMessage.model_validate(item))
+    except (
+        json.JSONDecodeError,
+        TypeError,
+        ValueError,
+    ) as exc:  # pragma: no cover - validation
+        raise HTTPException(
+            status_code=400, detail=f"Invalid history payload: {exc}"
+        ) from exc
 
     attachments = list(files or [])
     payloads: List[bytes] = []
@@ -178,10 +266,17 @@ async def run_assistant(
         payloads.append(await file.read())
 
     messages = _build_history(history_messages)
-    messages.append({"role": "user", "content": _build_user_content(prompt, attachments, payloads)})
+    messages.append(
+        {
+            "role": "user",
+            "content": _build_user_content(prompt, attachments, payloads),
+        }
+    )
 
     try:
         response = await _call_openai(messages, model=model)
+    except HTTPException:
+        raise
     except Exception as exc:  # pragma: no cover - network failure
         LOGGER.exception("OpenAI call failed")
         raise HTTPException(status_code=502, detail=str(exc)) from exc
@@ -193,14 +288,28 @@ async def run_assistant(
 async def generate_briefing(payload: BriefingRequest) -> BriefingResponse:
     """일일 브리핑 생성. | Create a daily briefing."""
 
-    schedule_summary = json.dumps(payload.schedule, ensure_ascii=False, indent=2)
-    weather_summary = json.dumps(payload.weather_windows, ensure_ascii=False, indent=2)
-    prompt = (
-        "당신은 해상 물류 관제 전문가입니다. 아래 데이터를 참고하여 200자 내외의 한국어 일일 브리핑을 작성하세요."
-        "\n- 현재 시각: {time}\n- 선박명: {vessel}\n- 현재 항차: {voyage}\n- 선박 상태: {status}\n"
-        "- 전체 일정: {schedule}\n- 기상 윈도우: {weather}\n"
-        "브리핑은 핵심 일정, 위험, 권고사항을 bullet로 정리하세요."
-    ).format(
+    schedule_summary = json.dumps(
+        payload.schedule,
+        ensure_ascii=False,
+        indent=2,
+    )
+    weather_summary = json.dumps(
+        payload.weather_windows,
+        ensure_ascii=False,
+        indent=2,
+    )
+    prompt_template = (
+        "당신은 해상 물류 관제 전문가입니다. "
+        "아래 데이터를 참고하여 200자 내외의 한국어 일일 브리핑을 작성하세요."
+        "\n- 현재 시각: {time}"
+        "\n- 선박명: {vessel}"
+        "\n- 현재 항차: {voyage}"
+        "\n- 선박 상태: {status}"
+        "\n- 전체 일정: {schedule}"
+        "\n- 기상 윈도우: {weather}"
+        "\n브리핑은 핵심 일정, 위험, 권고사항을 bullet로 정리하세요."
+    )
+    prompt = prompt_template.format(
         time=payload.current_time,
         vessel=payload.vessel_name,
         voyage=payload.current_voyage or "N/A",
@@ -214,15 +323,30 @@ async def generate_briefing(payload: BriefingRequest) -> BriefingResponse:
             [
                 {
                     "role": "system",
-                    "content": "당신은 HVDC 프로젝트 물류 전문가입니다. 일일 브리핑을 한국어로 작성하세요.",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": (
+                                "당신은 HVDC 프로젝트 물류 전문가입니다. "
+                                "일일 브리핑을 한국어로 작성하세요."
+                            ),
+                        }
+                    ],
                 },
                 {
                     "role": "user",
-                    "content": prompt,
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": prompt,
+                        }
+                    ],
                 },
             ],
             model=payload.model,
         )
+    except HTTPException:
+        raise
     except Exception as exc:  # pragma: no cover - network failure
         LOGGER.exception("OpenAI call failed")
         raise HTTPException(status_code=502, detail=str(exc)) from exc
@@ -232,4 +356,5 @@ async def generate_briefing(payload: BriefingRequest) -> BriefingResponse:
 
 if __name__ == "__main__":
     import uvicorn
+
     uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/openai_gateway.py
+++ b/openai_gateway.py
@@ -1,0 +1,235 @@
+"""OpenAI 연동 FastAPI 백엔드. | FastAPI backend wired with OpenAI."""
+
+from __future__ import annotations
+
+import base64
+import io
+import json
+import logging
+import os
+from typing import Iterable, List, Literal, Sequence
+
+from fastapi import FastAPI, File, Form, HTTPException, UploadFile
+from fastapi.middleware.cors import CORSMiddleware
+from openai import AsyncOpenAI
+from openai.types.chat import ChatCompletion
+from pydantic import BaseModel, ConfigDict, Field
+from PyPDF2 import PdfReader
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class LogiBaseModel(BaseModel):
+    """로지스틱 도메인 공통 베이스 모델. | Common logistics base model."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+
+class ChatMessage(LogiBaseModel):
+    """사용자/AI 메시지 구조. | Chat message schema."""
+
+    role: Literal["user", "assistant", "system"]
+    content: str = Field(..., max_length=6000)
+
+
+class BriefingRequest(LogiBaseModel):
+    """일일 브리핑 요청 본문. | Daily briefing payload."""
+
+    current_time: str
+    vessel_name: str
+    vessel_status: str
+    current_voyage: str | None = None
+    schedule: List[dict] = Field(default_factory=list)
+    weather_windows: List[dict] = Field(default_factory=list)
+
+
+class BriefingResponse(LogiBaseModel):
+    """일일 브리핑 응답. | Daily briefing response."""
+
+    briefing: str
+
+
+class AssistantResponse(LogiBaseModel):
+    """AI 어시스턴트 응답. | AI assistant response."""
+
+    answer: str
+
+
+_async_client: AsyncOpenAI | None = None
+
+
+def _require_client() -> AsyncOpenAI:
+    """OpenAI 클라이언트를 생성. | Build an OpenAI client."""
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise HTTPException(status_code=500, detail="OPENAI_API_KEY is not configured")
+    global _async_client
+    if _async_client is None:
+        _async_client = AsyncOpenAI(api_key=api_key)
+    return _async_client
+
+
+def _pdf_to_text(payload: bytes) -> str:
+    """PDF를 텍스트로 추출. | Extract text from PDF."""
+
+    reader = PdfReader(io.BytesIO(payload))
+    text_chunks: List[str] = []
+    for page in reader.pages:
+        snippet = page.extract_text() or ""
+        text_chunks.append(snippet)
+    return "\n".join(text_chunks)
+
+
+def _image_to_base64(file: UploadFile, payload: bytes) -> dict:
+    """이미지를 base64로 인코딩. | Encode image to base64."""
+
+    data_url = f"data:{file.content_type};base64,{base64.b64encode(payload).decode('utf-8')}"
+    return {"type": "input_image", "image_url": data_url}
+
+
+def _build_user_content(prompt: str, files: Iterable[UploadFile], raw_payloads: List[bytes]) -> str:
+    """사용자 메시지 콘텐츠 구성. | Compose user content payload."""
+
+    content_parts = [prompt]
+    for idx, file in enumerate(files):
+        data = raw_payloads[idx]
+        if file.content_type and file.content_type.startswith("image/"):
+            # For images, we'll include a reference in the text
+            content_parts.append(f"\n[첨부 이미지: {file.filename}]")
+        elif (file.content_type == "application/pdf") or file.filename.lower().endswith(".pdf"):
+            pdf_text = _pdf_to_text(data)[:8000]
+            descriptor = f"\n[첨부 PDF: {file.filename}]\n"
+            content_parts.append(descriptor + pdf_text)
+        else:
+            try:
+                decoded = data.decode("utf-8")
+            except UnicodeDecodeError:
+                decoded = base64.b64encode(data).decode("utf-8")
+                decoded = f"[base64-encoded attachment]\n{decoded[:6000]}"
+            content_parts.append(f"\n[첨부 파일: {file.filename}]\n{decoded[:8000]}")
+    return "\n".join(content_parts)
+
+
+def _extract_output_text(response: ChatCompletion) -> str:
+    """Chat Completion 결과에서 텍스트 추출. | Extract text from Chat Completion."""
+
+    try:
+        return response.choices[0].message.content
+    except (AttributeError, IndexError, KeyError):
+        return "Error: Could not extract response text"
+
+
+async def _call_openai(messages: List[dict], *, model: str) -> ChatCompletion:
+    """OpenAI Responses API 호출. | Invoke OpenAI Responses API."""
+
+    client = _require_client()
+    return await client.chat.completions.create(model=model, messages=messages)
+
+
+def _build_history(messages: Sequence[ChatMessage]) -> List[dict]:
+    """Chat Completion용 메시지 배열 구성. | Build chat completion messages."""
+
+    history: List[dict] = []
+    for item in messages:
+        history.append({
+            "role": item.role,
+            "content": item.content
+        })
+    return history
+
+
+app = FastAPI(title="HVDC Logistics AI Gateway", version="1.0.0")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.get("/health")
+async def healthcheck() -> dict:
+    """헬스체크. | Service health check."""
+
+    return {"status": "ok"}
+
+
+@app.post("/api/assistant", response_model=AssistantResponse)
+async def run_assistant(
+    prompt: str = Form(..., max_length=4000),
+    history: str = Form("[]"),
+    files: List[UploadFile] | None = File(default=None),
+    model: str = Form("gpt-4.1-mini"),
+) -> AssistantResponse:
+    """어시스턴트 호출. | Execute assistant call."""
+
+    try:
+        raw_history = json.loads(history)
+        history_messages = [ChatMessage.model_validate(item) for item in raw_history]
+    except (json.JSONDecodeError, TypeError, ValueError) as exc:  # pragma: no cover - validation
+        raise HTTPException(status_code=400, detail=f"Invalid history payload: {exc}") from exc
+
+    attachments = list(files or [])
+    payloads: List[bytes] = []
+    for file in attachments:
+        payloads.append(await file.read())
+
+    messages = _build_history(history_messages)
+    messages.append({"role": "user", "content": _build_user_content(prompt, attachments, payloads)})
+
+    try:
+        response = await _call_openai(messages, model=model)
+    except Exception as exc:  # pragma: no cover - network failure
+        LOGGER.exception("OpenAI call failed")
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+    return AssistantResponse(answer=_extract_output_text(response))
+
+
+@app.post("/api/briefing", response_model=BriefingResponse)
+async def generate_briefing(payload: BriefingRequest) -> BriefingResponse:
+    """일일 브리핑 생성. | Create a daily briefing."""
+
+    schedule_summary = json.dumps(payload.schedule, ensure_ascii=False, indent=2)
+    weather_summary = json.dumps(payload.weather_windows, ensure_ascii=False, indent=2)
+    prompt = (
+        "당신은 해상 물류 관제 전문가입니다. 아래 데이터를 참고하여 200자 내외의 한국어 일일 브리핑을 작성하세요."
+        "\n- 현재 시각: {time}\n- 선박명: {vessel}\n- 현재 항차: {voyage}\n- 선박 상태: {status}\n"
+        "- 전체 일정: {schedule}\n- 기상 윈도우: {weather}\n"
+        "브리핑은 핵심 일정, 위험, 권고사항을 bullet로 정리하세요."
+    ).format(
+        time=payload.current_time,
+        vessel=payload.vessel_name,
+        voyage=payload.current_voyage or "N/A",
+        status=payload.vessel_status,
+        schedule=schedule_summary,
+        weather=weather_summary,
+    )
+
+    try:
+        response = await _call_openai(
+            [
+                {
+                    "role": "system",
+                    "content": "당신은 HVDC 프로젝트 물류 전문가입니다. 일일 브리핑을 한국어로 작성하세요.",
+                },
+                {
+                    "role": "user",
+                    "content": prompt,
+                },
+            ],
+            model=payload.model,
+        )
+    except Exception as exc:  # pragma: no cover - network failure
+        LOGGER.exception("OpenAI call failed")
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+    return BriefingResponse(briefing=_extract_output_text(response))
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi>=0.104.0
+uvicorn[standard]>=0.24.0
+openai>=1.0.0
+pydantic>=2.0.0
+PyPDF2>=3.0.0
+python-multipart>=0.0.6

--- a/tests/test_openai_gateway.py
+++ b/tests/test_openai_gateway.py
@@ -69,7 +69,7 @@ def test_assistant_with_image_and_text(
             SimpleNamespace(
                 type="message",
                 message=SimpleNamespace(
-                    content=[SimpleNamespace(type="text", text="완료")]
+                    content=[SimpleNamespace(type="output_text", text="완료")]
                 ),
             )
         ]
@@ -105,7 +105,7 @@ def test_assistant_with_image_and_text(
     assert any(
         item.get("text", "").startswith("[파일 첨부")
         for item in user_block
-        if item["type"] == "text"
+        if item["type"] == "input_text"
     )
 
 

--- a/tests/test_openai_gateway.py
+++ b/tests/test_openai_gateway.py
@@ -1,0 +1,191 @@
+"""openai_gateway FastAPI endpoints tests."""
+
+from __future__ import annotations
+
+import base64
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import openai_gateway  # noqa: E402
+
+Payload = openai_gateway.MessagePayload
+
+
+@pytest.fixture(autouse=True)
+def _reset_gateway(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure OpenAI client globals reset for isolation."""
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    openai_gateway._async_client = None
+    openai_gateway._dotenv_loaded = False
+    yield
+    openai_gateway._async_client = None
+    openai_gateway._dotenv_loaded = False
+
+
+def _client() -> TestClient:
+    return TestClient(openai_gateway.app)
+
+
+def test_healthcheck() -> None:
+    """GET /health returns ok."""
+
+    with _client() as client:
+        response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_require_client_without_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Missing OPENAI_API_KEY raises an HTTPException."""
+
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    openai_gateway._async_client = None
+    openai_gateway._dotenv_loaded = False
+    with pytest.raises(openai_gateway.HTTPException) as exc:
+        openai_gateway._require_client()
+    assert exc.value.status_code == 500
+    assert "OPENAI_API_KEY" in exc.value.detail
+
+
+def test_assistant_with_image_and_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Assistant endpoint handles image and text attachments."""
+
+    captured: dict[str, Any] = {}
+
+    class FakeResponse:
+        output = [
+            SimpleNamespace(
+                type="message",
+                message=SimpleNamespace(
+                    content=[SimpleNamespace(type="text", text="완료")]
+                ),
+            )
+        ]
+
+    async def fake_call(messages: Payload, *, model: str) -> Any:
+        captured["messages"] = messages
+        return FakeResponse()
+
+    monkeypatch.setattr(openai_gateway, "_call_openai", fake_call)
+
+    png_bytes = base64.b64decode(
+        (
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4n"
+            "GNgYAAAAAMAASsJTYQAAAAASUVORK5CYII="
+        )
+    )
+    files = [
+        ("files", ("snapshot.png", png_bytes, "image/png")),
+        ("files", ("notes.txt", "hazard log", "text/plain")),
+    ]
+    data = {"prompt": "기상 분석", "history": "[]", "model": "gpt-4.1-mini"}
+
+    with _client() as client:
+        response = client.post("/api/assistant", data=data, files=files)
+
+    assert response.status_code == 200
+    assert response.json()["answer"] == "완료"
+    payload = captured["messages"]
+    assert isinstance(payload, list)
+    user_block = payload[-1]["content"]
+    types = [item["type"] for item in user_block]
+    assert "input_image" in types
+    assert any(
+        item.get("text", "").startswith("[파일 첨부")
+        for item in user_block
+        if item["type"] == "text"
+    )
+
+
+def test_briefing_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Briefing endpoint returns text from Responses API choices."""
+
+    class FakeResponse:
+        def __init__(self, text: str) -> None:
+            self.choices = [
+                SimpleNamespace(
+                    message=SimpleNamespace(content=text),
+                )
+            ]
+
+    async def fake_call(messages: Payload, *, model: str) -> Any:
+        assert model == "gpt-4.1-mini"
+        # Ensure payload includes weather levels
+        last = messages[-1]["content"][0]["text"]
+        assert "sail level" in last.lower() or "기상" in last
+        return FakeResponse("요약")
+
+    monkeypatch.setattr(openai_gateway, "_call_openai", fake_call)
+
+    payload = {
+        "current_time": "2025-09-28T12:00:00Z",
+        "vessel_name": "JOPETWIL 71",
+        "vessel_status": "Weather Standby",
+        "current_voyage": "69th",
+        "schedule": [
+            {
+                "id": "69th",
+                "cargo": "Sand",
+                "etd": "2025-09-28T16:00:00Z",
+                "eta": "2025-09-29T04:00:00Z",
+                "status": "Scheduled",
+            }
+        ],
+        "weather_windows": [
+            {
+                "start": "2025-09-29T00:00:00Z",
+                "end": "2025-09-29T06:00:00Z",
+                "sail_level": "Warn",
+                "discharge_level": "NoGo",
+                "waveM": 1.6,
+                "windKt": 24,
+                "visKm": 3.2,
+            }
+        ],
+        "model": "gpt-4.1-mini",
+    }
+
+    with _client() as client:
+        response = client.post("/api/briefing", json=payload)
+
+    assert response.status_code == 200
+    assert response.json()["briefing"] == "요약"
+
+
+def test_require_client_reuses_instance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_require_client caches AsyncOpenAI instance."""
+
+    created: list[str] = []
+
+    class DummyClient:
+        def __init__(self, api_key: str) -> None:
+            self.api_key = api_key
+            self.responses = SimpleNamespace(
+                create=lambda **_: None,
+            )
+
+    def fake_async_openai(api_key: str) -> DummyClient:
+        created.append(api_key)
+        return DummyClient(api_key)
+
+    monkeypatch.setattr(openai_gateway, "AsyncOpenAI", fake_async_openai)
+
+    first = openai_gateway._require_client()
+    second = openai_gateway._require_client()
+
+    assert first is second
+    assert created == ["sk-test"]


### PR DESCRIPTION
## Summary
- surface an inline attachment tray in the vessel panel so pasted captures stay visible outside the assistant modal
- reuse the assistant attachment renderer for both panels to keep removal controls and previews consistent
- document the inline attachment workflow across the README and changelog

## Testing
- black --check .
- isort --check-only .
- flake8 *(fails: command not found)*
- pytest -q
- coverage run -m pytest *(fails: command not found)*
- mypy --strict --follow-imports=skip openai_gateway.py *(fails: existing typing issues)*

------
https://chatgpt.com/codex/tasks/task_e_68d9541154288327892b8c00f9e40b21