### PR TITLE
Add marine weather CLI orchestration and auto alerts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,26 @@
+# Weather Vessel environment example
+STORMGLASS_API_KEY=
+STORMGLASS_ENDPOINT=https://api.stormglass.io/v2/weather/point
+OPEN_METEO_ENDPOINT=https://marine-api.open-meteo.com/v1/marine
+NOAA_WW3_ENDPOINT=https://nomads.ncep.noaa.gov/api/noaa_ww3
+
+# Risk thresholds (metres / knots)
+WV_MEDIUM_HS=2.0
+WV_HIGH_HS=3.0
+WV_MEDIUM_WIND=22.0
+WV_HIGH_WIND=28.0
+
+# Notification defaults
+WV_EMAIL_SENDER=ops@example.com
+WV_EMAIL_RECIPIENTS=captain@example.com
+WV_SMTP_HOST=smtp.example.com
+WV_SMTP_PORT=587
+WV_SMTP_TLS=true
+WV_SMTP_USERNAME=
+WV_SMTP_PASSWORD=
+WV_SLACK_WEBHOOK=
+WV_TELEGRAM_BOT_TOKEN=
+WV_TELEGRAM_CHAT_ID=
+
+# Output configuration
+WV_OUTPUT_DIR=outputs

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 100
+extend-ignore = E203,W503

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## [Unreleased]
+### Added
+- Enable AI weather insight panel with screenshot uploads analysed through the OpenAI gateway.
+
+### Fixed
+- Handle missing `OPENAI_API_KEY` gracefully by loading `.env` configuration and surfacing
+  configuration errors directly from the OpenAI gateway endpoints.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 ## [Unreleased]
 ### Added
 - Enable AI weather insight panel with screenshot uploads analysed through the OpenAI gateway.
+- Support clipboard paste and drag-and-drop ingestion for ADNOC weather screenshots so control tower operators can analyse live captures without saving files manually.
+- Provide in-app API gateway configuration with persistent storage to target custom OpenAI deployment ports.
 
 ### Fixed
 - Handle missing `OPENAI_API_KEY` gracefully by loading `.env` configuration and surfacing
   configuration errors directly from the OpenAI gateway endpoints.
+- Surface detailed OpenAI gateway errors in the UI when assistant or briefing calls fail instead of returning opaque 502 messages.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,17 @@
 
 ## [Unreleased]
 ### Added
-- Enable AI weather insight panel with screenshot uploads analysed through the OpenAI gateway.
-- Support clipboard paste and drag-and-drop ingestion for ADNOC weather screenshots so control tower operators can analyse live captures without saving files manually.
-- Provide in-app API gateway configuration with persistent storage to target custom OpenAI deployment ports.
+- Introduced `wv` Typer CLI with `check`, `schedule`, and `notify` workflows backed by Stormglass, Open-Meteo Marine, and NOAA WaveWatch III providers.
+- Implemented disk-backed cache (`~/.wv/cache`) with three-hour TTL and provider fallback/resilience logic.
+- Added weekly voyage planner that prints ASCII tables and exports CSV + ICS schedules with risk notes.
+- Delivered email, Slack, and Telegram notification adapters plus twice-daily Asia/Dubai auto-check scheduler.
+- Published `.env.example`, `plan.md`, and comprehensive pytest coverage for providers, risk rules, scheduler, notifications, and CLI.
+
+### Changed
+- Replaced legacy FastAPI usage docs with CLI-centric README guidance, including cron and Task Scheduler recipes.
+- Centralized configuration via `pyproject.toml` with strict tooling defaults (`black`, `isort`, `flake8`, `mypy`).
+- Normalized numeric outputs to two decimal places and ensured bilingual docstrings across new modules.
 
 ### Fixed
-- Handle missing `OPENAI_API_KEY` gracefully by loading `.env` configuration and surfacing
-  configuration errors directly from the OpenAI gateway endpoints.
-- Surface detailed OpenAI gateway errors in the UI when assistant or briefing calls fail instead of returning opaque 502 messages.
+- Resolved timezone drift by hard-coding Asia/Dubai context inside scheduling and notification flows.
+- Ensured provider outages (HTTP 429/timeout) automatically cascade to fallbacks or serve cached responses.

--- a/PATCH.MD
+++ b/PATCH.MD
@@ -1,0 +1,1016 @@
+diff --git a/logistics_control_tower_v2.html b/logistics_control_tower_v2.html
+index bb2612ea5d46286a36cd032a1e7c8ea8afaa3aaf..2178a725dd980b2d7610cd6649aba355fac580c4 100644
+--- a/logistics_control_tower_v2.html
++++ b/logistics_control_tower_v2.html
+@@ -1,81 +1,91 @@
+ <!DOCTYPE html>
+ <html lang="ko">
+ <head>
+   <meta charset="UTF-8" />
+   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+   <title>Logistics Control Tower v2.5</title>
+   <script src="https://cdn.tailwindcss.com"></script>
+   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" crossorigin=""/>
+   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" crossorigin=""></script>
+   <style>
+-    body{background:#0f172a;color:#e2e8f0;font-family:'Segoe UI',sans-serif}
++    body{background:radial-gradient(circle at top,#1e293b 0%,#0f172a 55%,#020617 100%);color:#e2e8f0;font-family:'Segoe UI',sans-serif}
+     .leaflet-container{background:#1f2937;border-radius:.75rem}
+     .leaflet-tooltip{background:rgba(15,23,42,.95);color:#fff;border:1px solid #475569;box-shadow:none;font-weight:600;padding:4px 8px}
+     .scrollbar-hide::-webkit-scrollbar{display:none}.scrollbar-hide{-ms-overflow-style:none;scrollbar-width:none}
+     .modal{transition:opacity .25s ease;z-index:10000}
+     body.modal-open{overflow:hidden}
+     #map{position:relative;z-index:0}
+     .leaflet-tooltip,.leaflet-popup{z-index:500!important}
+     .row-current{background:rgba(59,130,246,.15)}
+     .kbd{border:1px solid #475569;border-bottom-width:2px;border-radius:.375rem;padding:.15rem .35rem;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+-    .tag{font-size:.75rem;padding:.1rem .4rem;border:1px solid #475569;border-radius:.5rem}
++    .tag{font-size:.75rem;padding:.1rem .4rem;border:1px solid rgba(148,163,184,.6);border-radius:.5rem;background:rgba(148,163,184,.12)}
+     .chip{display:inline-flex;align-items:center;gap:.25rem;padding:.25rem .5rem;border-radius:.5rem;background:rgba(79,70,229,.2);color:#c7d2fe;font-size:.75rem}
+     .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+     .btn { min-height: 44px; min-width: 44px; } /* 터치 타겟 44px 기준 */
++    .panel-scroll{max-height:clamp(260px,45vh,520px);overflow-y:auto;scrollbar-color:#475569 transparent}
++    .panel-scroll::-webkit-scrollbar{width:6px}
++    .panel-scroll::-webkit-scrollbar-thumb{background:rgba(148,163,184,.45);border-radius:9999px}
++    .pill{display:inline-flex;align-items:center;gap:.25rem;padding:.2rem .6rem;border-radius:9999px;font-weight:600;font-size:.75rem;border:1px solid rgba(94,234,212,.3);background:rgba(45,212,191,.12);color:#a7f3d0;text-transform:uppercase;letter-spacing:.02em}
++    .pill-success{background:rgba(34,197,94,.18);border-color:rgba(34,197,94,.4);color:#bbf7d0}
++    .pill-warn{background:rgba(234,179,8,.22);border-color:rgba(234,179,8,.45);color:#fef3c7}
++    .pill-danger{background:rgba(248,113,113,.2);border-color:rgba(248,113,113,.45);color:#fecaca}
++    #assistant-dropzone{transition:background .2s ease,border-color .2s ease}
++    #assistant-dropzone.drop-active{border-color:rgba(14,165,233,.75);background:rgba(14,165,233,.08);box-shadow:0 0 0 1px rgba(14,165,233,.2)}
++    #assistant-attachments img{box-shadow:0 4px 12px rgba(15,23,42,.65)}
+ 
+     @media (prefers-contrast: more) {
+         :root {
+             --accent: #00b4ff;
+             --text: #ffffff;
+             --muted: #e2e8f0;
+         }
+         .panel, .status-card, .control-card { border-color: rgba(255,255,255,0.6); }
+-        .pill { background: rgba(0,180,255,0.25); }
++        .pill, .pill-success, .pill-warn, .pill-danger { border-color: rgba(255,255,255,0.7); }
+     }
+   </style>
+ </head>
+ <body class="p-4">
+   <!-- Skip link for keyboard users -->
+   <a href="#main" class="sr-only" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;"
+      onfocus="this.style.position='static';this.style.width='auto';this.style.height='auto';this.style.padding='0.5rem 0.75rem';this.style.background='#0ea5e9';this.style.color='#000';this.style.borderRadius='8px';">
+      Skip to main content
+   </a>
+   <main id="main" class="grid grid-cols-1 lg:grid-cols-5 gap-4 h-[95vh]" role="main" aria-live="polite">
+     <div id="map" class="lg:col-span-3 rounded-xl shadow-xl border border-slate-700 h-full min-h-[400px]" 
+          role="img" aria-label="Vessel tracking map showing route from MW4 to AGI" tabindex="0"></div>
+ 
+     <aside class="lg:col-span-2 flex flex-col gap-4 h-full" role="complementary" aria-label="Vessel control and schedule information">
+-      <div id="info-panel" class="bg-slate-900 p-4 rounded-xl shadow-lg border border-slate-700">
++      <div id="info-panel" class="bg-slate-900/90 p-4 rounded-xl shadow-2xl border border-slate-700 panel-scroll backdrop-blur-sm space-y-4">
+         <div class="flex items-center justify-between">
+           <h2 class="text-xl font-bold border-b border-slate-600 pb-2 mb-3">Vessel Control</h2>
+           <div class="flex items-center gap-2">
+             <span class="tag">Local: Asia/Dubai</span>
+-            <div class="pill" id="marineBadge" title="Marine snapshot">Hs: -- m · Wind: -- kt</div>
++            <div class="pill pill-warn" id="marineBadge" title="Marine snapshot">Hs: -- m · Wind: -- kt</div>
+           </div>
+         </div>
+-        <div id="vessel-info"><p class="text-slate-400">Loading vessel data...</p></div>
++        <div id="vessel-info" class="space-y-4"><p class="text-slate-400">Loading vessel data...</p></div>
+ 
+         <div class="grid grid-cols-2 gap-2 mt-4">
+           <button id="briefing-btn" class="w-full bg-indigo-600 hover:bg-indigo-700 text-white font-bold py-2 px-3 rounded-lg transition-colors flex items-center justify-center gap-2 text-sm"
+                   aria-describedby="briefing-desc">✨ Daily Briefing</button>
+           <button id="assistant-btn" class="w-full bg-purple-600 hover:bg-purple-700 text-white font-bold py-2 px-3 rounded-lg transition-colors flex items-center justify-center gap-2 text-sm"
+                   aria-describedby="assistant-desc">🤖 Ask AI Assistant</button>
+         </div>
+         <div class="sr-only" id="briefing-desc">Generate AI-powered daily logistics briefing</div>
+         <div class="sr-only" id="assistant-desc">Open AI assistant chat for logistics questions</div>
+ 
+         <div class="mt-4 grid grid-cols-2 gap-2">
+           <label class="w-full">
+             <input type="file" id="file-schedule" class="hidden" accept=".csv,.json"/>
+             <span id="label-schedule" class="w-full inline-flex items-center justify-center bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-3 rounded-lg cursor-pointer">Upload Schedule (CSV/JSON)</span>
+           </label>
+           <label class="w-full">
+             <input type="file" id="file-weather" class="hidden" accept=".csv"/>
+             <span id="label-weather" class="w-full inline-flex items-center justify-center bg-emerald-600 hover:bg-emerald-700 text-white font-bold py-2 px-3 rounded-lg cursor-pointer">Upload Weather (CSV)</span>
+           </label>
+         </div>
+         <p class="mt-3 text-xs text-slate-400">Tips: Press <span class="kbd">Esc</span> to close modals. 파일 포맷은 하단 가이드를 참고. API는 <span class="chip" id="api-status">API: Offline</span></p>
+       </div>
+ 
+       <div class="bg-slate-900 p-4 rounded-xl shadow-lg border border-slate-700 flex-grow flex flex-col h-1/2">
+         <div class="flex items-center justify-between border-b border-slate-600 pb-2 mb-3">
+@@ -128,97 +138,100 @@
+        role="dialog" aria-modal="true" aria-labelledby="modal-title" aria-describedby="modal-content" aria-hidden="true">
+     <div class="bg-slate-900 rounded-xl shadow-2xl p-6 w-full max-w-lg border border-slate-700" role="document">
+       <h2 id="modal-title" class="text-2xl font-bold text-indigo-400 mb-4">✨ AI-Generated Output</h2>
+       <div id="modal-content" class="text-slate-300 bg-slate-950 p-4 rounded-md min-h-[150px] whitespace-pre-line overflow-y-auto max-h-[60vh]"></div>
+       <button id="close-modal-btn" class="mt-6 w-full bg-slate-700 hover:bg-slate-600 text-white font-bold py-2 px-4 rounded-lg transition-colors">Close</button>
+     </div>
+   </div>
+ 
+   <div id="assistant-modal" class="modal fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center p-4 opacity-0 pointer-events-none"
+        role="dialog" aria-modal="true" aria-labelledby="assistant-title" aria-describedby="assistant-conversation" aria-hidden="true">
+     <div class="bg-slate-900 rounded-xl shadow-2xl p-6 w-full max-w-2xl border border-slate-700 flex flex-col h-[80vh]" role="document">
+       <div class="flex items-center justify-between mb-4">
+         <h2 id="assistant-title" class="text-2xl font-bold text-purple-400">🤖 AI Logistics Assistant</h2>
+         <div class="flex items-center gap-2">
+           <label class="text-xs text-slate-300">Model
+             <select id="assistant-model" class="ml-2 bg-slate-800 border border-slate-600 text-slate-100 text-xs rounded px-2 py-1">
+               <option value="gpt-4.1-mini">gpt-4.1-mini</option>
+               <option value="gpt-4o-mini">gpt-4o-mini</option>
+             </select>
+           </label>
+         </div>
+       </div>
+       <div id="assistant-conversation" class="flex-grow bg-slate-950 p-4 rounded-md overflow-y-auto scrollbar-hide space-y-2 text-sm">
+         <div class="text-slate-400">무엇을 도와드릴까요? (예: “다음 3일 스케줄 요약”)<br/>첨부 버튼으로 캡처/문서를 추가하면 자동 분석됩니다.</div>
+       </div>
+-      <div class="mt-3 bg-slate-800/60 border border-slate-600 rounded-lg p-3">
++      <div id="assistant-dropzone" class="mt-3 bg-slate-800/60 border border-dashed border-slate-600 rounded-lg p-3">
+         <div class="flex items-center justify-between">
+           <div class="text-xs text-slate-300 font-semibold">Attachments</div>
+           <button id="assistant-attach-btn" class="text-xs bg-slate-700 hover:bg-slate-600 text-white px-2 py-1 rounded">+ Add</button>
+         </div>
++        <p class="mt-2 text-[11px] text-slate-400">+ 버튼을 누르거나 파일을 끌어다 놓고, 스크린 캡처는 붙여넣기(Ctrl/⌘+V)로 추가하세요.</p>
+         <input type="file" id="assistant-file" class="hidden" accept="image/*,.pdf,.txt,.csv" multiple />
+-        <div id="assistant-attachments" class="mt-2 text-xs text-slate-400 space-y-1"></div>
++        <div id="assistant-attachments" class="mt-3 text-xs text-slate-300 space-y-2 min-h-[3rem]" aria-live="polite"></div>
+       </div>
+       <form id="assistant-form" class="mt-3 flex gap-2" role="form" aria-label="AI Assistant Chat">
+         <input type="text" id="assistant-input" class="flex-grow bg-slate-800 text-white rounded-lg p-2 border border-slate-600 focus:outline-none focus:ring-2 focus:ring-purple-500" 
+                placeholder="Ask a question..." aria-label="Type your question here" aria-describedby="assistant-input-desc">
+         <button type="submit" class="bg-purple-600 hover:bg-purple-700 text-white font-bold py-2 px-4 rounded-lg transition-colors"
+                 aria-label="Send message">Send</button>
+       </form>
+       <div class="sr-only" id="assistant-input-desc">Type your logistics question and press Enter or click Send</div>
+       <div class="flex gap-2 mt-2 text-xs text-slate-400">
+         <button id="assistant-reset" type="button" class="px-3 py-1 rounded bg-slate-700 hover:bg-slate-600 text-white">Clear Chat</button>
+         <span id="assistant-usage" class="italic"></span>
+       </div>
+       <button id="close-assistant-btn" class="mt-3 w-full bg-slate-700 hover:bg-slate-600 text-white font-bold py-2 px-4 rounded-lg transition-colors">Close</button>
+     </div>
+   </div>
+ 
+   <script>
+     // requestIdleCallback 폴리필 (간단)
+     window.requestIdleCallback ||= (cb)=>setTimeout(()=>cb({didTimeout:false,timeRemaining:()=>0}), 1);
+     window.cancelIdleCallback ||= (id)=>clearTimeout(id);
+ 
+   document.addEventListener('DOMContentLoaded', () => {
+     const API_BASE = window.APP_CONFIG?.apiBase ?? 'http://localhost:8000';
+     const tz = 'Asia/Dubai';
+     
+     // Scenario presets and port coordinates
+     const scenarioPresets = {
+       base:        { delayOnRisk: 4.0,  hs_caution: 1.50, hs_nogo: 2.50, wind_caution: 18, wind_nogo: 28 },
+       weather:     { delayOnRisk: 6.0,  hs_caution: 1.20, hs_nogo: 2.00, wind_caution: 16, wind_nogo: 24 },
+       congestion:  { delayOnRisk: 5.0,  hs_caution: 1.60, hs_nogo: 2.60, wind_caution: 20, wind_nogo: 30 },
+       inspection:  { delayOnRisk: 3.5, hs_caution: 1.80, hs_nogo: 2.80, wind_caution: 22, wind_nogo: 32 }
+     };
+     const RULE = scenarioPresets.base;
+     
+     const portCoords = {
+       'Shanghai':   { lat: 31.2304, lon: 121.4737 },
+       'Singapore':  { lat: 1.3521,  lon: 103.8198 },
+       'Colombo':    { lat: 6.9271,  lon: 79.8612  },
+       'Jebel Ali':  { lat: 25.006,  lon: 55.065   }
+     };
++    const MARINE_CACHE_TTL_MS = 5 * 60 * 1000;
++    const marineSnapshotCache = new Map();
+     const fmtIso = (d)=> new Date(d).toISOString();
+     const toLocal = (d)=> new Date(d).toLocaleString('en-GB',{ timeZone: tz, dateStyle:'short', timeStyle:'medium' });
+     const pad2 = (n)=> String(n).padStart(2,'0');
+     const clamp = (v,min,max)=> Math.max(min, Math.min(max,v));
+     const parseNum = (s)=> Number(String(s||'').trim());
+     const parseISO = (s)=> {
+       if(!s) return null;
+       const t = String(s).trim().replace(' ', 'T');
+       return isNaN(Date.parse(t)) ? null : new Date(t);
+     };
+     const parseCSV = (text)=>{
+       const lines = text.trim().split(/\r?\n/);
+       const header = lines.shift().split(',').map(h=>h.trim());
+       return lines.map(line=>{
+         const cells = line.split(',').map(c=>c.trim());
+         const obj={};
+         header.forEach((h,i)=> obj[h]=cells[i]);
+         return obj;
+       });
+     };
+ 
+     async function checkApiHealth(){
+       const badge = document.getElementById('api-status');
+       try{
+         const res = await fetch(`${API_BASE}/health`);
+@@ -286,99 +299,138 @@
+     }
+     const segments=[]; let totalMeters=0;
+     for(let i=0;i<vesselData.route.length-1;i++){
+       const a=vesselData.route[i], b=vesselData.route[i+1];
+       const m=haversine(a,b);
+       segments.push({a,b,m,accStart:totalMeters,accEnd:totalMeters+m});
+       totalMeters+=m;
+     }
+     function interpolateOnRoute(progress){
+       const target=clamp(progress,0,1)*totalMeters;
+       const seg=segments.find(s=>target>=s.accStart && target<=s.accEnd) || segments[segments.length-1];
+       const t=(target-seg.accStart)/(seg.m||1);
+       const lat=seg.a[0]+(seg.b[0]-seg.a[0])*t;
+       const lon=seg.a[1]+(seg.b[1]-seg.a[1])*t;
+       return [Number(lat.toFixed(5)), Number(lon.toFixed(5))];
+     }
+ 
+     const infoPanel = document.getElementById('vessel-info');
+     const timeDisplay = document.getElementById('sim-time');
+     const scheduleContainer = document.getElementById('schedule-container');
+     const alertContainer = document.getElementById('alert-container');
+     const assistantConversation = document.getElementById('assistant-conversation');
+     const assistantUsage = document.getElementById('assistant-usage');
+     const assistantFileInput = document.getElementById('assistant-file');
+     const assistantAttachments = document.getElementById('assistant-attachments');
++    const assistantDropzone = document.getElementById('assistant-dropzone');
+     const assistantModelSelect = document.getElementById('assistant-model');
+     let assistantHistory = [];
+     let pendingAttachments = [];
+ 
+     function updateInfoPanel(){
+       const cur=vesselData.currentVoyageId||'N/A';
++      const activeLeg = voyageSchedule.find(v=>v.id===vesselData.currentVoyageId);
++      const progressRatio = clamp(vesselData.progress ?? 0,0,1);
++      const progressPct = progressRatio * 100;
++      const etdDisplay = activeLeg?.etd ? toLocal(activeLeg.etd) : 'N/A';
++      const etaDisplay = activeLeg?.eta ? toLocal(activeLeg.eta) : 'N/A';
+       infoPanel.innerHTML =
+-        `<h3 class="text-2xl font-bold text-cyan-400">${vesselData.name}</h3>
+-         <p class="text-sm text-slate-400">IMO: ${vesselData.imo} / MMSI: ${vesselData.mmsi}</p>
+-         <div class="mt-4 space-y-2">
+-           <div><strong>Current Voyage:</strong> <span class="font-mono text-lg">${cur}</span></div>
+-           <div><strong>Status:</strong> <span class="font-mono text-lg text-yellow-300">${vesselData.status}</span></div>
++        `<div class="flex items-start justify-between gap-3">
++           <div>
++             <h3 class="text-2xl font-bold text-cyan-400">${vesselData.name}</h3>
++             <p class="text-sm text-slate-400">IMO: ${vesselData.imo} / MMSI: ${vesselData.mmsi}</p>
++           </div>
++           <span class="px-2 py-1 rounded-md text-xs bg-slate-800/80 border border-slate-600">${tz}</span>
++         </div>
++         <div class="grid grid-cols-2 gap-3 text-sm">
++           <div class="bg-slate-800/60 border border-slate-700 rounded-lg p-3">
++             <p class="text-slate-400 text-xs uppercase tracking-wider">Current Voyage</p>
++             <p class="mt-1 font-mono text-lg text-emerald-300">${cur}</p>
++           </div>
++           <div class="bg-slate-800/60 border border-slate-700 rounded-lg p-3">
++             <p class="text-slate-400 text-xs uppercase tracking-wider">Status</p>
++             <p class="mt-1 font-semibold text-sky-300">${vesselData.status}</p>
++           </div>
++         </div>
++         <div class="bg-slate-800/60 border border-slate-700 rounded-lg p-3">
++           <div class="flex items-center justify-between text-xs text-slate-400">
++             <span>Leg Progress</span>
++             <span class="font-mono text-slate-200">${progressPct.toFixed(2)}%</span>
++          </div>
++          <div class="w-full h-2 bg-slate-900/80 rounded-full mt-2">
++             <div class="h-2 rounded-full bg-gradient-to-r from-cyan-400 via-sky-500 to-emerald-400" style="width:${Math.min(100,Math.max(0,progressPct)).toFixed(2)}%"></div>
++           </div>
++           <div class="mt-3 grid grid-cols-2 gap-2 text-xs text-slate-400">
++             <div>
++               <span class="block uppercase tracking-wide">ETD</span>
++               <span class="font-mono text-slate-200">${etdDisplay}</span>
++             </div>
++             <div>
++               <span class="block uppercase tracking-wide">ETA</span>
++               <span class="font-mono text-slate-200">${etaDisplay}</span>
++             </div>
++           </div>
+          </div>`;
+     }
+ 
+     async function renderSchedule(){
+       const scheduleBody = document.getElementById('schedule-body');
+       if (!scheduleBody) return;
+       
+       document.getElementById('schedule-container').setAttribute('aria-busy','true');
+       scheduleBody.innerHTML = '';
+       
++      const marineSnap = await updateMarineForLeg('Jebel Ali');
++      const baseIoi = Number.isFinite(marineSnap?.ioi) ? Number(marineSnap.ioi) : 50;
++
+       for (let index = 0; index < voyageSchedule.length; index += 1) {
+         const v = voyageSchedule[index];
+         let c="text-slate-300", pill="";
+         if(v.status==="In Transit") { c="text-blue-300"; pill='<span class="tag">Sailing</span>'; }
+         else if(v.status==="Delayed") { c="text-rose-300"; pill='<span class="tag">Delayed</span>'; }
+         else if(v.status==="Completed") { c="text-emerald-300"; pill='<span class="tag">Arrived</span>'; }
+         const hi=v.id===vesselData.currentVoyageId ? "row-current" : "";
+-        
++
+         // Marine data for this port (simplified for current structure)
+-        const snap = await updateMarineForLeg('Jebel Ali'); // Default port for now
+-        const ioi = snap?.ioi ?? 50;
+-        const decision = ioi >= 75 ? { tag: 'Go', tone: 'success' } : 
+-                        ioi >= 55 ? { tag: 'Caution', tone: 'warn' } : 
++        const ioi = baseIoi;
++        const decision = ioi >= 75 ? { tag: 'Go', tone: 'success' } :
++                        ioi >= 55 ? { tag: 'Caution', tone: 'warn' } :
+                         { tag: 'No-Go', tone: 'danger' };
+-        
++        const formattedIoi = Number.isFinite(ioi) ? Number(ioi).toFixed(2) : '50.00';
++
+         const row = document.createElement('tr');
+         row.id = `voyage-${v.id}`;
+         row.className = `border-t border-slate-700 ${hi}`;
+         row.setAttribute('role', 'row');
+         row.innerHTML = `
+           <td class="p-2 font-bold" role="gridcell" aria-describedby="th-voyage">${v.id}</td>
+           <td class="p-2" role="gridcell" aria-describedby="th-cargo">${v.cargo}</td>
+           <td class="p-2" role="gridcell" aria-describedby="th-etd">${toLocal(v.etd)}</td>
+           <td class="p-2" role="gridcell" aria-describedby="th-eta">${toLocal(v.eta)}</td>
+           <td class="p-2 ${c} font-semibold" role="gridcell" aria-describedby="th-status">${v.status} ${pill}</td>
+-          <td class="p-2" role="gridcell" aria-describedby="th-ioi">${ioi}</td>
+-          <td class="p-2" role="gridcell" aria-describedby="th-decision"><span class="pill ${decision.tone === 'danger' ? 'danger' : ''}">${decision.tag}</span></td>
++          <td class="p-2" role="gridcell" aria-describedby="th-ioi">${formattedIoi}</td>
++          <td class="p-2" role="gridcell" aria-describedby="th-decision"><span class="pill pill-${decision.tone}">${decision.tag}</span></td>
+         `;
+         scheduleBody.appendChild(row);
+       }
+       
+       document.getElementById('schedule-container').setAttribute('aria-busy','false');
+ 
+       if(vesselData.currentVoyageId){
+         const row=document.getElementById(`voyage-${vesselData.currentVoyageId}`);
+         if(row) row.scrollIntoView({block:'center',behavior:'smooth'});
+       }
+     }
+ 
+     function setInfo(msgHtml, tone='info'){
+       const color = tone==='warn' ? 'bg-yellow-900 border-yellow-500 text-yellow-100'
+                    : tone==='danger' ? 'bg-rose-900 border-rose-500 text-rose-100'
+                    : 'bg-slate-950 border-slate-600 text-slate-200';
+       alertContainer.innerHTML = `<div class="${color} px-4 py-3 rounded border">${msgHtml}</div>`;
+     }
+ 
+     const LIM = {
+       waveWarnM: 1.75, waveNoGoM: 2.25,
+       windWarnKt: 24, windNoGoKt: 30,
+       visNoGoKm: 1.0
+     };
+ 
+@@ -557,120 +609,190 @@
+     });
+ 
+     const briefingModal=document.getElementById('briefing-modal');
+     const assistantModal=document.getElementById('assistant-modal');
+     const modalTitle=document.getElementById('modal-title');
+     const modalContent=document.getElementById('modal-content');
+ 
+     function openModal(el){ 
+       el.classList.remove('opacity-0','pointer-events-none'); 
+       el.setAttribute('aria-hidden', 'false');
+       document.body.classList.add('modal-open'); 
+       // Focus management
+       const focusableElements = el.querySelectorAll('button, input, select, textarea, [tabindex]:not([tabindex="-1"])');
+       if(focusableElements.length > 0) {
+         focusableElements[0].focus();
+       }
+     }
+     function closeModal(el){ 
+       el.classList.add('opacity-0','pointer-events-none'); 
+       el.setAttribute('aria-hidden', 'true');
+       document.body.classList.remove('modal-open'); 
+     }
+     [briefingModal,assistantModal].forEach(m=> m.addEventListener('click', e=>{ if(e.target===m) closeModal(m); }));
+     document.addEventListener('keydown', e=>{ if(e.key==='Escape'){ [briefingModal,assistantModal].forEach(closeModal); } });
+ 
++    function guessExtension(type){
++      if(!type) return '';
++      if(type.includes('png')) return '.png';
++      if(type.includes('jpeg') || type.includes('jpg')) return '.jpg';
++      if(type.includes('gif')) return '.gif';
++      if(type.includes('webp')) return '.webp';
++      if(type.includes('pdf')) return '.pdf';
++      if(type.includes('csv')) return '.csv';
++      if(type.includes('plain')) return '.txt';
++      return '';
++    }
++
++    function addAttachmentsFromFileList(fileList){
++      const files = Array.from(fileList || []);
++      if(files.length===0) return;
++      const stamped = files.map((file,idx)=>{
++        if(file.name) return file;
++        const ext = guessExtension(file.type || '');
++        const timestamp = new Date().toISOString().replace(/[.:]/g,'-');
++        return new File([file], `capture-${timestamp}-${idx+1}${ext}`, { type: file.type || 'application/octet-stream' });
++      });
++      pendingAttachments = pendingAttachments.concat(stamped);
++      renderAttachmentList();
++    }
++
+     function renderAttachmentList(){
+       if(pendingAttachments.length===0){
+-        assistantAttachments.innerHTML = '<div class="text-slate-500">No attachments selected.</div>';
++        assistantAttachments.innerHTML = '<div class="text-slate-500 text-[11px]">첨부된 파일이 없습니다. 스크린 캡처 붙여넣기를 지원합니다.</div>';
+         return;
+       }
+       assistantAttachments.innerHTML = pendingAttachments.map((file,idx)=>{
+-        return `<div class="flex justify-between items-center bg-slate-900/80 px-2 py-1 rounded">
+-                  <span class="truncate max-w-[14rem]">${file.name}</span>
+-                  <button data-index="${idx}" class="text-rose-300 hover:text-rose-400 remove-attachment">Remove</button>
++        const isImage = (file.type || '').startsWith('image/');
++        const preview = isImage
++          ? `<img src="${URL.createObjectURL(file)}" alt="${file.name} preview" class="w-12 h-12 object-cover rounded-md border border-slate-700" onload="URL.revokeObjectURL(this.src)">`
++          : `<span class="w-12 h-12 flex items-center justify-center rounded-md bg-slate-900/70 border border-slate-700 text-lg">📄</span>`;
++        const sizeKb = file.size ? (file.size/1024).toFixed(2) : '0.00';
++        return `<div class="flex items-center gap-3 bg-slate-900/70 px-3 py-2 rounded-lg border border-slate-800/70">
++                  ${preview}
++                  <div class="flex-1 min-w-0">
++                    <p class="text-slate-200 text-sm truncate">${file.name}</p>
++                    <p class="text-slate-500 text-[11px]">${file.type || 'unknown'} • ${sizeKb} KB</p>
++                  </div>
++                  <button data-index="${idx}" class="text-rose-300 hover:text-rose-200 text-xs remove-attachment">Remove</button>
+                 </div>`;
+       }).join('');
+       assistantAttachments.querySelectorAll('.remove-attachment').forEach(btn=>{
+         btn.addEventListener('click',(ev)=>{
+-          const idx = Number(ev.target.getAttribute('data-index'));
++          const idx = Number(ev.currentTarget.getAttribute('data-index'));
+           pendingAttachments.splice(idx,1);
+           renderAttachmentList();
+         });
+       });
+     }
+ 
+-    assistantAttachments.innerHTML = '<div class="text-slate-500">No attachments selected.</div>';
++    renderAttachmentList();
+ 
+     document.getElementById('assistant-attach-btn').addEventListener('click', ()=> assistantFileInput.click());
+     assistantFileInput.addEventListener('change', (event)=>{
+-      pendingAttachments = Array.from(event.target.files || []);
+-      renderAttachmentList();
++      addAttachmentsFromFileList(event.target.files || []);
++      assistantFileInput.value = '';
++    });
++
++    ['dragenter','dragover'].forEach(evt=>{
++      assistantDropzone.addEventListener(evt,(event)=>{
++        event.preventDefault();
++        assistantDropzone.classList.add('drop-active');
++      });
++    });
++    ['dragleave','dragend'].forEach(evt=>{
++      assistantDropzone.addEventListener(evt,()=>{
++        assistantDropzone.classList.remove('drop-active');
++      });
++    });
++    assistantDropzone.addEventListener('drop',(event)=>{
++      event.preventDefault();
++      assistantDropzone.classList.remove('drop-active');
++      addAttachmentsFromFileList(event.dataTransfer?.files || []);
++    });
++
++    document.addEventListener('paste',(event)=>{
++      if(assistantModal.getAttribute('aria-hidden') === 'true') return;
++      const items = event.clipboardData?.items || [];
++      const files = [];
++      for(const item of items){
++        if(item.kind === 'file'){
++          const file = item.getAsFile();
++          if(file) files.push(file);
++        }
++      }
++      if(files.length){
++        event.preventDefault();
++        addAttachmentsFromFileList(files);
++      }
+     });
+ 
+     document.getElementById('assistant-reset').addEventListener('click', ()=>{
+       assistantHistory = [];
+       assistantConversation.innerHTML = '<div class="text-slate-400">무엇을 도와드릴까요? (예: “다음 3일 스케줄 요약”)</div>';
+       assistantUsage.textContent='';
++      pendingAttachments = [];
++      renderAttachmentList();
+     });
+ 
+     async function callAssistant(prompt, attachments){
+       const formData = new FormData();
+       formData.append('prompt', prompt);
+       formData.append('history', JSON.stringify(assistantHistory));
+       formData.append('model', assistantModelSelect.value);
+       attachments.forEach(file=> formData.append('files', file, file.name));
+       const res = await fetch(`${API_BASE}/api/assistant`, { method:'POST', body: formData });
+       if(!res.ok){
+         const text = await res.text();
+         throw new Error(text || 'Assistant call failed');
+       }
+       const data = await res.json();
+       assistantHistory.push({role:'user', content: prompt});
+       assistantHistory.push({role:'assistant', content: data.answer});
+       assistantUsage.textContent = `Last response model: ${assistantModelSelect.value}`;
+       return data.answer;
+     }
+ 
+     async function fetchBriefing(){
+       modalTitle.textContent = '✨ Daily Briefing';
+       modalContent.innerHTML = '생성 중...';
+       openModal(briefingModal);
+       const payload = {
+         current_time: currentSimDate.toISOString(),
+         vessel_name: vesselData.name,
+         vessel_status: vesselData.status,
+         current_voyage: vesselData.currentVoyageId,
+         schedule: voyageSchedule,
+         weather_windows: weatherWindows.map(w=>({
+           start: w.start ? w.start.toISOString?.() || w.start : w.start,
+           end: w.end ? w.end.toISOString?.() || w.end : w.end,
+           level: w.level,
+           waveM: w.waveM,
+           windKt: w.windKt,
+           visKm: w.visKm
+-        }))
++        })),
++        model: assistantModelSelect.value
+       };
+       try{
+         const res = await fetch(`${API_BASE}/api/briefing`, {
+           method:'POST',
+           headers:{'Content-Type':'application/json'},
+           body: JSON.stringify(payload)
+         });
+         if(!res.ok) throw new Error(await res.text());
+         const data = await res.json();
+         modalContent.innerHTML = data.briefing.replace(/\n/g,'<br>');
+       }catch(err){
+         console.error(err);
+         const cur = voyageSchedule.find(v=>v.id===vesselData.currentVoyageId);
+         const fallback = `현재 시각 ${toLocal(currentSimDate)}.\n진행 항차: ${cur?.id || 'N/A'} / 화물: ${cur?.cargo || 'N/A'} / 상태: ${vesselData.status}.`;
+         modalContent.innerHTML = `${fallback.replace(/\n/g,'<br>')}<br><br><span class="text-rose-300">AI Briefing unavailable: ${err.message}</span>`;
+       }
+     }
+ 
+     async function runRiskScan(){
+       const prompt = `다음 일정과 기상창을 기반으로 3가지 위험 시나리오와 대응 권고를 bullet로 정리해줘.\n일정: ${JSON.stringify(voyageSchedule)}\n기상: ${JSON.stringify(weatherWindows)}`;
+       setInfo('AI 위험 스캔 실행 중...', 'info');
+       try{
+         const answer = await callAssistant(prompt, []);
+         setInfo(answer.replace(/\n/g,'<br>'), 'warn');
+       }catch(err){
+@@ -690,58 +812,77 @@
+       const q=input.value.trim(); if(!q) return;
+       assistantConversation.innerHTML += `<div class="text-right"><span class="bg-purple-800/80 p-2 rounded-lg inline-block">${q}</span></div>`;
+       input.value='';
+       assistantConversation.scrollTop=assistantConversation.scrollHeight;
+       try{
+         const ans = await callAssistant(q, pendingAttachments);
+         assistantConversation.innerHTML += `<div class="text-left"><span class="bg-slate-800 p-2 rounded-lg inline-block">${ans.replace(/\n/g,'<br>')}</span></div>`;
+         assistantConversation.scrollTop=assistantConversation.scrollHeight;
+         pendingAttachments = [];
+         assistantFileInput.value = '';
+         renderAttachmentList();
+       }catch(err){
+         assistantConversation.innerHTML += `<div class="text-left text-rose-300">${err.message}</div>`;
+         assistantConversation.scrollTop=assistantConversation.scrollHeight;
+       }
+     });
+ 
+     document.getElementById('btn-reset').addEventListener('click', ()=>{
+       currentSimDate = new Date("2025-09-28T12:00:00Z");
+       vesselData.currentVoyageId = null;
+       vesselData.status = "Ready @ MW4";
+       setInfo('시뮬레이션 시계가 초기화되었습니다.');
+     });
+ 
+     // Marine data functions
+-    async function updateMarineForLeg(portName) {
+-      // 워커로 오프로드
+-      const snap = await fetchMarineAndIOIInWorker(portName);
++    function applyMarineBadge(snap) {
++      const badge = document.getElementById('marineBadge');
++      badge.classList.remove('pill-success','pill-warn','pill-danger');
++      let tone = 'warn';
++      if (snap && typeof snap.ioi === 'number') {
++        if (snap.ioi >= 75) tone = 'success';
++        else if (snap.ioi < 55) tone = 'danger';
++      }
++      badge.classList.add(`pill-${tone}`);
+       if (snap && snap.hs != null && snap.windKt != null) {
+-        marineBadge.textContent = `Hs: ${snap.hs.toFixed(2)} m · Wind: ${Math.round(snap.windKt)} kt`;
++        badge.textContent = `Hs: ${snap.hs.toFixed(2)} m · Wind: ${snap.windKt.toFixed(2)} kt`;
+       } else {
+-        marineBadge.textContent = `Marine: n/a`;
++        badge.textContent = `Marine: n/a`;
++      }
++    }
++
++    async function updateMarineForLeg(portName) {
++      const now = Date.now();
++      const cached = marineSnapshotCache.get(portName);
++      if (cached && (now - cached.timestamp) < MARINE_CACHE_TTL_MS) {
++        applyMarineBadge(cached.snap);
++        return cached.snap;
+       }
++      // 워커로 오프로드
++      const snap = await fetchMarineAndIOIInWorker(portName);
++      marineSnapshotCache.set(portName, { snap, timestamp: now });
++      applyMarineBadge(snap);
+       return snap;
+     }
+ 
+     // ===== Worker 생성 (Blob URL) : IOI 계산 + Marine fetch 오프로드 =====
+     const workerCode = `
+       self.addEventListener('message', async (e) => {
+         const { type, payload } = e.data || {};
+         if (type === 'marine+ioi') {
+           const { port, coords, RULE } = payload;
+           try {
+             const params = new URLSearchParams({
+               latitude: String(coords.lat),
+               longitude: String(coords.lon),
+               hourly: ['wave_height','wind_speed_10m','swell_wave_period'].join(','),
+               timezone: 'auto'
+             });
+             const url = 'https://marine-api.open-meteo.com/v1/marine?' + params.toString();
+             const r = await fetch(url);
+             const j = await r.json();
+             const idx = 0;
+             const hs = j?.hourly?.wave_height?.[idx] ?? null;
+             const wsms = j?.hourly?.wind_speed_10m?.[idx] ?? null;
+             const sp = j?.hourly?.swell_wave_period?.[idx] ?? null;
+             const windKt = wsms != null ? (wsms * 1.94384) : null;
+             // IOI 계산 (워커쪽 동일 로직)
+diff --git a/openai_gateway.py b/openai_gateway.py
+index a46dbf7046d9d902b24c413854dde533462b8562..a6b7dcd7c6ead5a9bbd7a82f2af6195de335af56 100644
+--- a/openai_gateway.py
++++ b/openai_gateway.py
+@@ -1,235 +1,323 @@
+ """OpenAI 연동 FastAPI 백엔드. | FastAPI backend wired with OpenAI."""
+ 
+ from __future__ import annotations
+ 
+ import base64
+ import io
+ import json
+ import logging
+ import os
+-from typing import Iterable, List, Literal, Sequence
++from typing import Any, Iterable, List, Literal, Sequence
+ 
+ from fastapi import FastAPI, File, Form, HTTPException, UploadFile
+ from fastapi.middleware.cors import CORSMiddleware
+ from openai import AsyncOpenAI
+-from openai.types.chat import ChatCompletion
+ from pydantic import BaseModel, ConfigDict, Field
+ from PyPDF2 import PdfReader
+ 
+-
+ LOGGER = logging.getLogger(__name__)
+ 
+ 
+ class LogiBaseModel(BaseModel):
+     """로지스틱 도메인 공통 베이스 모델. | Common logistics base model."""
+ 
+     model_config = ConfigDict(extra="forbid", populate_by_name=True)
+ 
+ 
+ class ChatMessage(LogiBaseModel):
+     """사용자/AI 메시지 구조. | Chat message schema."""
+ 
+     role: Literal["user", "assistant", "system"]
+     content: str = Field(..., max_length=6000)
+ 
+ 
+ class BriefingRequest(LogiBaseModel):
+     """일일 브리핑 요청 본문. | Daily briefing payload."""
+ 
+     current_time: str
+     vessel_name: str
+     vessel_status: str
+     current_voyage: str | None = None
+     schedule: List[dict] = Field(default_factory=list)
+     weather_windows: List[dict] = Field(default_factory=list)
++    model: str = Field(default="gpt-4.1-mini", max_length=64)
+ 
+ 
+ class BriefingResponse(LogiBaseModel):
+     """일일 브리핑 응답. | Daily briefing response."""
+ 
+     briefing: str
+ 
+ 
+ class AssistantResponse(LogiBaseModel):
+     """AI 어시스턴트 응답. | AI assistant response."""
+ 
+     answer: str
+ 
+ 
+ _async_client: AsyncOpenAI | None = None
+ 
+ 
+ def _require_client() -> AsyncOpenAI:
+     """OpenAI 클라이언트를 생성. | Build an OpenAI client."""
+ 
+     api_key = os.getenv("OPENAI_API_KEY")
+     if not api_key:
+-        raise HTTPException(status_code=500, detail="OPENAI_API_KEY is not configured")
++        error_message = "OPENAI_API_KEY is not configured"
++        raise HTTPException(status_code=500, detail=error_message)
+     global _async_client
+     if _async_client is None:
+         _async_client = AsyncOpenAI(api_key=api_key)
+     return _async_client
+ 
+ 
+ def _pdf_to_text(payload: bytes) -> str:
+     """PDF를 텍스트로 추출. | Extract text from PDF."""
+ 
+     reader = PdfReader(io.BytesIO(payload))
+     text_chunks: List[str] = []
+     for page in reader.pages:
+         snippet = page.extract_text() or ""
+         text_chunks.append(snippet)
+     return "\n".join(text_chunks)
+ 
+ 
+ def _image_to_base64(file: UploadFile, payload: bytes) -> dict:
+     """이미지를 base64로 인코딩. | Encode image to base64."""
+ 
+-    data_url = f"data:{file.content_type};base64,{base64.b64encode(payload).decode('utf-8')}"
+-    return {"type": "input_image", "image_url": data_url}
++    data_url = "data:{media};base64,{payload}".format(
++        media=file.content_type,
++        payload=base64.b64encode(payload).decode("utf-8"),
++    )
++    return {"type": "input_image", "image_url": {"url": data_url}}
+ 
+ 
+-def _build_user_content(prompt: str, files: Iterable[UploadFile], raw_payloads: List[bytes]) -> str:
++def _build_user_content(
++    prompt: str, files: Iterable[UploadFile], raw_payloads: List[bytes]
++) -> List[dict[str, Any]]:
+     """사용자 메시지 콘텐츠 구성. | Compose user content payload."""
+ 
+-    content_parts = [prompt]
++    content: List[dict[str, Any]] = [{"type": "text", "text": prompt}]
+     for idx, file in enumerate(files):
+         data = raw_payloads[idx]
++        filename = file.filename or f"attachment-{idx+1}"
+         if file.content_type and file.content_type.startswith("image/"):
+-            # For images, we'll include a reference in the text
+-            content_parts.append(f"\n[첨부 이미지: {file.filename}]")
+-        elif (file.content_type == "application/pdf") or file.filename.lower().endswith(".pdf"):
++            content.append(
++                {
++                    "type": "text",
++                    "text": f"[이미지 첨부: {filename}]",
++                }
++            )
++            content.append(_image_to_base64(file, data))
++            continue
++
++        is_pdf_content = file.content_type == "application/pdf"
++        if is_pdf_content or filename.lower().endswith(".pdf"):
+             pdf_text = _pdf_to_text(data)[:8000]
+-            descriptor = f"\n[첨부 PDF: {file.filename}]\n"
+-            content_parts.append(descriptor + pdf_text)
+-        else:
+-            try:
+-                decoded = data.decode("utf-8")
+-            except UnicodeDecodeError:
+-                decoded = base64.b64encode(data).decode("utf-8")
+-                decoded = f"[base64-encoded attachment]\n{decoded[:6000]}"
+-            content_parts.append(f"\n[첨부 파일: {file.filename}]\n{decoded[:8000]}")
+-    return "\n".join(content_parts)
+-
+-
+-def _extract_output_text(response: ChatCompletion) -> str:
++            descriptor = f"[PDF 첨부: {filename}]\n{pdf_text}"
++            content.append(
++                {
++                    "type": "text",
++                    "text": descriptor,
++                }
++            )
++            continue
++
++        try:
++            decoded = data.decode("utf-8")
++        except UnicodeDecodeError:
++            decoded = base64.b64encode(data).decode("utf-8")
++            decoded = f"[base64-encoded attachment]\n{decoded[:6000]}"
++        content.append(
++            {
++                "type": "text",
++                "text": f"[파일 첨부: {filename}]\n{decoded[:8000]}",
++            }
++        )
++
++    return content
++
++
++def _extract_output_text(response: Any) -> str:
+     """Chat Completion 결과에서 텍스트 추출. | Extract text from Chat Completion."""
+ 
++    outputs = getattr(response, "output", None)
++    if outputs:
++        texts: List[str] = []
++        for item in outputs:
++            if getattr(item, "type", None) != "message":
++                continue
++            message = getattr(item, "message", None)
++            if not message:
++                continue
++            for block in getattr(message, "content", []) or []:
++                if getattr(block, "type", None) == "text":
++                    text_value = getattr(block, "text", "")
++                    if text_value:
++                        texts.append(text_value)
++        if texts:
++            return "\n".join(texts)
++
+     try:
+         return response.choices[0].message.content
+     except (AttributeError, IndexError, KeyError):
+         return "Error: Could not extract response text"
+ 
+ 
+-async def _call_openai(messages: List[dict], *, model: str) -> ChatCompletion:
++async def _call_openai(messages: List[dict[str, Any]], *, model: str) -> Any:
+     """OpenAI Responses API 호출. | Invoke OpenAI Responses API."""
+ 
+     client = _require_client()
+-    return await client.chat.completions.create(model=model, messages=messages)
++    return await client.responses.create(model=model, input=messages)
+ 
+ 
+-def _build_history(messages: Sequence[ChatMessage]) -> List[dict]:
++def _build_history(messages: Sequence[ChatMessage]) -> List[dict[str, Any]]:
+     """Chat Completion용 메시지 배열 구성. | Build chat completion messages."""
+ 
+-    history: List[dict] = []
++    history: List[dict[str, Any]] = []
+     for item in messages:
+-        history.append({
+-            "role": item.role,
+-            "content": item.content
+-        })
++        history.append(
++            {
++                "role": item.role,
++                "content": [
++                    {"type": "text", "text": item.content},
++                ],
++            }
++        )
+     return history
+ 
+ 
+ app = FastAPI(title="HVDC Logistics AI Gateway", version="1.0.0")
+ app.add_middleware(
+     CORSMiddleware,
+     allow_origins=["*"],
+     allow_credentials=True,
+     allow_methods=["*"],
+     allow_headers=["*"],
+ )
+ 
+ 
+ @app.get("/health")
+ async def healthcheck() -> dict:
+     """헬스체크. | Service health check."""
+ 
+     return {"status": "ok"}
+ 
+ 
+ @app.post("/api/assistant", response_model=AssistantResponse)
+ async def run_assistant(
+     prompt: str = Form(..., max_length=4000),
+     history: str = Form("[]"),
+     files: List[UploadFile] | None = File(default=None),
+     model: str = Form("gpt-4.1-mini"),
+ ) -> AssistantResponse:
+     """어시스턴트 호출. | Execute assistant call."""
+ 
+     try:
+         raw_history = json.loads(history)
+-        history_messages = [ChatMessage.model_validate(item) for item in raw_history]
+-    except (json.JSONDecodeError, TypeError, ValueError) as exc:  # pragma: no cover - validation
+-        raise HTTPException(status_code=400, detail=f"Invalid history payload: {exc}") from exc
++        history_messages: List[ChatMessage] = []
++        for item in raw_history:
++            history_messages.append(ChatMessage.model_validate(item))
++    except (
++        json.JSONDecodeError,
++        TypeError,
++        ValueError,
++    ) as exc:  # pragma: no cover - validation
++        raise HTTPException(
++            status_code=400, detail=f"Invalid history payload: {exc}"
++        ) from exc
+ 
+     attachments = list(files or [])
+     payloads: List[bytes] = []
+     for file in attachments:
+         payloads.append(await file.read())
+ 
+     messages = _build_history(history_messages)
+-    messages.append({"role": "user", "content": _build_user_content(prompt, attachments, payloads)})
++    messages.append(
++        {
++            "role": "user",
++            "content": _build_user_content(prompt, attachments, payloads),
++        }
++    )
+ 
+     try:
+         response = await _call_openai(messages, model=model)
+     except Exception as exc:  # pragma: no cover - network failure
+         LOGGER.exception("OpenAI call failed")
+         raise HTTPException(status_code=502, detail=str(exc)) from exc
+ 
+     return AssistantResponse(answer=_extract_output_text(response))
+ 
+ 
+ @app.post("/api/briefing", response_model=BriefingResponse)
+ async def generate_briefing(payload: BriefingRequest) -> BriefingResponse:
+     """일일 브리핑 생성. | Create a daily briefing."""
+ 
+-    schedule_summary = json.dumps(payload.schedule, ensure_ascii=False, indent=2)
+-    weather_summary = json.dumps(payload.weather_windows, ensure_ascii=False, indent=2)
+-    prompt = (
+-        "당신은 해상 물류 관제 전문가입니다. 아래 데이터를 참고하여 200자 내외의 한국어 일일 브리핑을 작성하세요."
+-        "\n- 현재 시각: {time}\n- 선박명: {vessel}\n- 현재 항차: {voyage}\n- 선박 상태: {status}\n"
+-        "- 전체 일정: {schedule}\n- 기상 윈도우: {weather}\n"
+-        "브리핑은 핵심 일정, 위험, 권고사항을 bullet로 정리하세요."
+-    ).format(
++    schedule_summary = json.dumps(
++        payload.schedule,
++        ensure_ascii=False,
++        indent=2,
++    )
++    weather_summary = json.dumps(
++        payload.weather_windows,
++        ensure_ascii=False,
++        indent=2,
++    )
++    prompt_template = (
++        "당신은 해상 물류 관제 전문가입니다. "
++        "아래 데이터를 참고하여 200자 내외의 한국어 일일 브리핑을 작성하세요."
++        "\n- 현재 시각: {time}"
++        "\n- 선박명: {vessel}"
++        "\n- 현재 항차: {voyage}"
++        "\n- 선박 상태: {status}"
++        "\n- 전체 일정: {schedule}"
++        "\n- 기상 윈도우: {weather}"
++        "\n브리핑은 핵심 일정, 위험, 권고사항을 bullet로 정리하세요."
++    )
++    prompt = prompt_template.format(
+         time=payload.current_time,
+         vessel=payload.vessel_name,
+         voyage=payload.current_voyage or "N/A",
+         status=payload.vessel_status,
+         schedule=schedule_summary,
+         weather=weather_summary,
+     )
+ 
+     try:
+         response = await _call_openai(
+             [
+                 {
+                     "role": "system",
+-                    "content": "당신은 HVDC 프로젝트 물류 전문가입니다. 일일 브리핑을 한국어로 작성하세요.",
++                    "content": [
++                        {
++                            "type": "text",
++                            "text": (
++                                "당신은 HVDC 프로젝트 물류 전문가입니다. "
++                                "일일 브리핑을 한국어로 작성하세요."
++                            ),
++                        }
++                    ],
+                 },
+                 {
+                     "role": "user",
+-                    "content": prompt,
++                    "content": [
++                        {
++                            "type": "text",
++                            "text": prompt,
++                        }
++                    ],
+                 },
+             ],
+             model=payload.model,
+         )
+     except Exception as exc:  # pragma: no cover - network failure
+         LOGGER.exception("OpenAI call failed")
+         raise HTTPException(status_code=502, detail=str(exc)) from exc
+ 
+     return BriefingResponse(briefing=_extract_output_text(response))
+ 
+ 
+ if __name__ == "__main__":
+     import uvicorn
+-    uvicorn.run(app, host="0.0.0.0", port=8000)
+\ No newline at end of file
++
++    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A comprehensive maritime logistics control system with real-time vessel tracking
 
 ### 🌤️ Weather Integration
 - Marine weather data from Open-Meteo API
+- ADNOC weather screenshots interpreted by AI for rapid risk flagging
 - IOI (Index of Operability) calculation (0-100 scale)
 - Go/No-Go decision support based on weather conditions
 - Real-time marine snapshot display (wave height, wind speed)
@@ -20,6 +21,7 @@ A comprehensive maritime logistics control system with real-time vessel tracking
 - AI assistant for logistics questions
 - Risk analysis and mitigation recommendations
 - File upload support (PDF, images, CSV)
+- Dedicated AI weather insight panel for screenshot uploads
 
 ### 📊 Schedule Management
 - Voyage schedule management with CSV/JSON import
@@ -56,8 +58,10 @@ cd WEATHER-VESSEL
 pip install -r requirements.txt
 ```
 
-3. Set up environment variables:
+3. Set up environment variables (supports `.env` file in project root):
 ```bash
+echo "OPENAI_API_KEY=your-openai-api-key" >> .env
+# or export directly for the current shell
 export OPENAI_API_KEY="your-openai-api-key"
 ```
 
@@ -73,7 +77,7 @@ python -m uvicorn openai_gateway:app --host 0.0.0.0 --port 8000 --reload
 ### Basic Operations
 - **Vessel Tracking**: View real-time vessel position and route
 - **Schedule Upload**: Import voyage schedules via CSV/JSON
-- **Weather Data**: Upload weather data for risk analysis
+- **Weather Data**: Upload weather data (CSV) or ADNOC screenshots for risk analysis
 - **AI Assistant**: Ask questions about logistics operations
 - **Daily Briefing**: Generate AI-powered operational summaries
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A comprehensive maritime logistics control system with real-time vessel tracking
 ### 🌤️ Weather Integration
 - Marine weather data from Open-Meteo API
 - ADNOC weather screenshots interpreted by AI for rapid risk flagging
+- Clipboard paste and drag-and-drop ingestion for screenshot uploads
 - IOI (Index of Operability) calculation (0-100 scale)
 - Go/No-Go decision support based on weather conditions
 - Real-time marine snapshot display (wave height, wind speed)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,124 @@
+# Weather Vessel - Logistics Control Tower v2.5
+
+A comprehensive maritime logistics control system with real-time vessel tracking, weather integration, and AI-powered decision support.
+
+## Features
+
+### 🗺️ Real-time Vessel Tracking
+- Interactive Leaflet map with vessel route visualization
+- Real-time position updates and progress tracking
+- Route optimization and ETA calculations
+
+### 🌤️ Weather Integration
+- Marine weather data from Open-Meteo API
+- IOI (Index of Operability) calculation (0-100 scale)
+- Go/No-Go decision support based on weather conditions
+- Real-time marine snapshot display (wave height, wind speed)
+
+### 🤖 AI-Powered Features
+- Daily logistics briefing generation
+- AI assistant for logistics questions
+- Risk analysis and mitigation recommendations
+- File upload support (PDF, images, CSV)
+
+### 📊 Schedule Management
+- Voyage schedule management with CSV/JSON import
+- Weather-linked schedule adjustments
+- Risk simulation and control
+- Live status updates
+
+### ♿ Accessibility (WCAG 2.2 AA)
+- Keyboard navigation support
+- Screen reader compatibility
+- High contrast mode support
+- 44px minimum touch targets
+- Skip links and ARIA attributes
+
+## Technology Stack
+
+- **Frontend**: HTML5, CSS3, JavaScript (ES6+)
+- **Styling**: Tailwind CSS
+- **Maps**: Leaflet.js 1.9.4
+- **Backend**: FastAPI (Python)
+- **AI Integration**: OpenAI API
+- **Performance**: Web Workers, requestIdleCallback
+
+## Installation
+
+1. Clone the repository:
+```bash
+git clone https://github.com/macho715/WEATHER-VESSEL.git
+cd WEATHER-VESSEL
+```
+
+2. Install Python dependencies:
+```bash
+pip install -r requirements.txt
+```
+
+3. Set up environment variables:
+```bash
+export OPENAI_API_KEY="your-openai-api-key"
+```
+
+4. Start the FastAPI server:
+```bash
+python -m uvicorn openai_gateway:app --host 0.0.0.0 --port 8000 --reload
+```
+
+5. Open `logistics_control_tower_v2.html` in your browser
+
+## Usage
+
+### Basic Operations
+- **Vessel Tracking**: View real-time vessel position and route
+- **Schedule Upload**: Import voyage schedules via CSV/JSON
+- **Weather Data**: Upload weather data for risk analysis
+- **AI Assistant**: Ask questions about logistics operations
+- **Daily Briefing**: Generate AI-powered operational summaries
+
+### Advanced Features
+- **IOI Analysis**: Automatic operability assessment
+- **Risk Simulation**: Test different scenarios
+- **Weather Linking**: Automatic schedule adjustments based on weather
+- **File Analysis**: Upload documents for AI analysis
+
+## API Endpoints
+
+- `GET /health` - Health check
+- `POST /api/assistant` - AI assistant chat
+- `POST /api/briefing` - Generate daily briefing
+
+## Performance Optimizations
+
+- **Web Workers**: Marine data fetching in background threads
+- **Idle Callbacks**: Non-blocking UI updates
+- **Passive Event Listeners**: Optimized scroll/touch handling
+- **Lazy Loading**: Efficient resource management
+
+## Accessibility Features
+
+- **Keyboard Navigation**: Full keyboard support
+- **Screen Reader**: ARIA labels and roles
+- **High Contrast**: System preference detection
+- **Touch Targets**: 44px minimum size compliance
+- **Focus Management**: Proper focus handling in modals
+
+## Contributing
+
+1. Fork the repository
+2. Create a feature branch
+3. Make your changes
+4. Test thoroughly
+5. Submit a pull request
+
+## License
+
+This project is licensed under the MIT License - see the LICENSE file for details.
+
+## Acknowledgments
+
+- Open-Meteo for marine weather data
+- Leaflet for mapping functionality
+- OpenAI for AI capabilities
+- Tailwind CSS for styling framework

--- a/logistics_control_tower_v2.html
+++ b/logistics_control_tower_v2.html
@@ -44,7 +44,7 @@
     }
   </style>
 </head>
-<body class="p-4">
+<body class="p-4" data-api-base-url="http://localhost:8000">
   <!-- Skip link for keyboard users -->
   <a href="#main" class="sr-only" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;"
      onfocus="this.style.position='static';this.style.width='auto';this.style.height='auto';this.style.padding='0.5rem 0.75rem';this.style.background='#0ea5e9';this.style.color='#000';this.style.borderRadius='8px';">

--- a/logistics_control_tower_v2.html
+++ b/logistics_control_tower_v2.html
@@ -8,7 +8,7 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" crossorigin=""/>
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" crossorigin=""></script>
   <style>
-    body{background:#0f172a;color:#e2e8f0;font-family:'Segoe UI',sans-serif}
+    body{background:radial-gradient(circle at top,#1e293b 0%,#0f172a 55%,#020617 100%);color:#e2e8f0;font-family:'Segoe UI',sans-serif}
     .leaflet-container{background:#1f2937;border-radius:.75rem}
     .leaflet-tooltip{background:rgba(15,23,42,.95);color:#fff;border:1px solid #475569;box-shadow:none;font-weight:600;padding:4px 8px}
     .scrollbar-hide::-webkit-scrollbar{display:none}.scrollbar-hide{-ms-overflow-style:none;scrollbar-width:none}
@@ -18,10 +18,20 @@
     .leaflet-tooltip,.leaflet-popup{z-index:500!important}
     .row-current{background:rgba(59,130,246,.15)}
     .kbd{border:1px solid #475569;border-bottom-width:2px;border-radius:.375rem;padding:.15rem .35rem;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
-    .tag{font-size:.75rem;padding:.1rem .4rem;border:1px solid #475569;border-radius:.5rem}
+    .tag{font-size:.75rem;padding:.1rem .4rem;border:1px solid rgba(148,163,184,.6);border-radius:.5rem;background:rgba(148,163,184,.12)}
     .chip{display:inline-flex;align-items:center;gap:.25rem;padding:.25rem .5rem;border-radius:.5rem;background:rgba(79,70,229,.2);color:#c7d2fe;font-size:.75rem}
     .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
     .btn { min-height: 44px; min-width: 44px; } /* 터치 타겟 44px 기준 */
+    .panel-scroll{max-height:clamp(260px,45vh,520px);overflow-y:auto;scrollbar-color:#475569 transparent}
+    .panel-scroll::-webkit-scrollbar{width:6px}
+    .panel-scroll::-webkit-scrollbar-thumb{background:rgba(148,163,184,.45);border-radius:9999px}
+    .pill{display:inline-flex;align-items:center;gap:.25rem;padding:.2rem .6rem;border-radius:9999px;font-weight:600;font-size:.75rem;border:1px solid rgba(94,234,212,.3);background:rgba(45,212,191,.12);color:#a7f3d0;text-transform:uppercase;letter-spacing:.02em}
+    .pill-success{background:rgba(34,197,94,.18);border-color:rgba(34,197,94,.4);color:#bbf7d0}
+    .pill-warn{background:rgba(234,179,8,.22);border-color:rgba(234,179,8,.45);color:#fef3c7}
+    .pill-danger{background:rgba(248,113,113,.2);border-color:rgba(248,113,113,.45);color:#fecaca}
+    #assistant-dropzone{transition:background .2s ease,border-color .2s ease}
+    #assistant-dropzone.drop-active{border-color:rgba(14,165,233,.75);background:rgba(14,165,233,.08);box-shadow:0 0 0 1px rgba(14,165,233,.2)}
+    #assistant-attachments img{box-shadow:0 4px 12px rgba(15,23,42,.65)}
 
     @media (prefers-contrast: more) {
         :root {
@@ -30,7 +40,7 @@
             --muted: #e2e8f0;
         }
         .panel, .status-card, .control-card { border-color: rgba(255,255,255,0.6); }
-        .pill { background: rgba(0,180,255,0.25); }
+        .pill, .pill-success, .pill-warn, .pill-danger { border-color: rgba(255,255,255,0.7); }
     }
   </style>
 </head>
@@ -45,15 +55,15 @@
          role="img" aria-label="Vessel tracking map showing route from MW4 to AGI" tabindex="0"></div>
 
     <aside class="lg:col-span-2 flex flex-col gap-4 h-full" role="complementary" aria-label="Vessel control and schedule information">
-      <div id="info-panel" class="bg-slate-900 p-4 rounded-xl shadow-lg border border-slate-700">
+      <div id="info-panel" class="bg-slate-900/90 p-4 rounded-xl shadow-2xl border border-slate-700 panel-scroll backdrop-blur-sm space-y-4">
         <div class="flex items-center justify-between">
           <h2 class="text-xl font-bold border-b border-slate-600 pb-2 mb-3">Vessel Control</h2>
           <div class="flex items-center gap-2">
             <span class="tag">Local: Asia/Dubai</span>
-            <div class="pill" id="marineBadge" title="Marine snapshot">Hs: -- m · Wind: -- kt</div>
+            <div class="pill pill-warn" id="marineBadge" title="Marine snapshot">Hs: -- m · Wind: -- kt</div>
           </div>
         </div>
-        <div id="vessel-info"><p class="text-slate-400">Loading vessel data...</p></div>
+        <div id="vessel-info" class="space-y-4"><p class="text-slate-400">Loading vessel data...</p></div>
 
         <div class="grid grid-cols-2 gap-2 mt-4">
           <button id="briefing-btn" class="w-full bg-indigo-600 hover:bg-indigo-700 text-white font-bold py-2 px-3 rounded-lg transition-colors flex items-center justify-center gap-2 text-sm"
@@ -70,11 +80,19 @@
             <span id="label-schedule" class="w-full inline-flex items-center justify-center bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-3 rounded-lg cursor-pointer">Upload Schedule (CSV/JSON)</span>
           </label>
           <label class="w-full">
-            <input type="file" id="file-weather" class="hidden" accept=".csv"/>
-            <span id="label-weather" class="w-full inline-flex items-center justify-center bg-emerald-600 hover:bg-emerald-700 text-white font-bold py-2 px-3 rounded-lg cursor-pointer">Upload Weather (CSV)</span>
+            <input type="file" id="file-weather" class="hidden" accept=".csv,image/*"/>
+            <span id="label-weather" class="w-full inline-flex items-center justify-center bg-emerald-600 hover:bg-emerald-700 text-white font-bold py-2 px-3 rounded-lg cursor-pointer">Upload Weather (CSV / Image)</span>
           </label>
         </div>
         <p class="mt-3 text-xs text-slate-400">Tips: Press <span class="kbd">Esc</span> to close modals. 파일 포맷은 하단 가이드를 참고. API는 <span class="chip" id="api-status">API: Offline</span></p>
+      </div>
+
+      <div id="ai-analysis-panel" class="bg-slate-900/90 p-4 rounded-xl shadow-xl border border-slate-700 hidden" role="region" aria-label="AI weather analysis">
+        <div class="flex items-center justify-between border-b border-slate-600 pb-2 mb-3">
+          <h2 class="text-xl font-bold text-sky-300">✨ AI Weather Insight</h2>
+          <span class="tag text-xs">Screenshot Ready</span>
+        </div>
+        <div id="analysis-content" class="text-slate-200 bg-slate-950/80 rounded-lg p-3 text-sm leading-relaxed whitespace-pre-line"></div>
       </div>
 
       <div class="bg-slate-900 p-4 rounded-xl shadow-lg border border-slate-700 flex-grow flex flex-col h-1/2">
@@ -150,13 +168,14 @@
       <div id="assistant-conversation" class="flex-grow bg-slate-950 p-4 rounded-md overflow-y-auto scrollbar-hide space-y-2 text-sm">
         <div class="text-slate-400">무엇을 도와드릴까요? (예: “다음 3일 스케줄 요약”)<br/>첨부 버튼으로 캡처/문서를 추가하면 자동 분석됩니다.</div>
       </div>
-      <div class="mt-3 bg-slate-800/60 border border-slate-600 rounded-lg p-3">
+      <div id="assistant-dropzone" class="mt-3 bg-slate-800/60 border border-dashed border-slate-600 rounded-lg p-3">
         <div class="flex items-center justify-between">
           <div class="text-xs text-slate-300 font-semibold">Attachments</div>
           <button id="assistant-attach-btn" class="text-xs bg-slate-700 hover:bg-slate-600 text-white px-2 py-1 rounded">+ Add</button>
         </div>
+        <p class="mt-2 text-[11px] text-slate-400">+ 버튼을 누르거나 파일을 끌어다 놓고, 스크린 캡처는 붙여넣기(Ctrl/⌘+V)로 추가하세요.</p>
         <input type="file" id="assistant-file" class="hidden" accept="image/*,.pdf,.txt,.csv" multiple />
-        <div id="assistant-attachments" class="mt-2 text-xs text-slate-400 space-y-1"></div>
+        <div id="assistant-attachments" class="mt-3 text-xs text-slate-300 space-y-2 min-h-[3rem]" aria-live="polite"></div>
       </div>
       <form id="assistant-form" class="mt-3 flex gap-2" role="form" aria-label="AI Assistant Chat">
         <input type="text" id="assistant-input" class="flex-grow bg-slate-800 text-white rounded-lg p-2 border border-slate-600 focus:outline-none focus:ring-2 focus:ring-purple-500" 
@@ -191,12 +210,14 @@
     };
     const RULE = scenarioPresets.base;
     
-    const portCoords = {
-      'Shanghai':   { lat: 31.2304, lon: 121.4737 },
-      'Singapore':  { lat: 1.3521,  lon: 103.8198 },
-      'Colombo':    { lat: 6.9271,  lon: 79.8612  },
-      'Jebel Ali':  { lat: 25.006,  lon: 55.065   }
-    };
+     const portCoords = {
+       'Shanghai':   { lat: 31.2304, lon: 121.4737 },
+       'Singapore':  { lat: 1.3521,  lon: 103.8198 },
+       'Colombo':    { lat: 6.9271,  lon: 79.8612  },
+       'Jebel Ali':  { lat: 25.006,  lon: 55.065   }
+     };
+     const MARINE_CACHE_TTL_MS = 5 * 60 * 1000;
+     const marineSnapshotCache = new Map();
     const fmtIso = (d)=> new Date(d).toISOString();
     const toLocal = (d)=> new Date(d).toLocaleString('en-GB',{ timeZone: tz, dateStyle:'short', timeStyle:'medium' });
     const pad2 = (n)=> String(n).padStart(2,'0');
@@ -302,72 +323,113 @@
 
     const infoPanel = document.getElementById('vessel-info');
     const timeDisplay = document.getElementById('sim-time');
-    const scheduleContainer = document.getElementById('schedule-container');
-    const alertContainer = document.getElementById('alert-container');
-    const assistantConversation = document.getElementById('assistant-conversation');
-    const assistantUsage = document.getElementById('assistant-usage');
-    const assistantFileInput = document.getElementById('assistant-file');
-    const assistantAttachments = document.getElementById('assistant-attachments');
-    const assistantModelSelect = document.getElementById('assistant-model');
-    let assistantHistory = [];
-    let pendingAttachments = [];
+     const scheduleContainer = document.getElementById('schedule-container');
+     const alertContainer = document.getElementById('alert-container');
+     const aiAnalysisPanel = document.getElementById('ai-analysis-panel');
+     const analysisContent = document.getElementById('analysis-content');
+     const assistantConversation = document.getElementById('assistant-conversation');
+     const assistantUsage = document.getElementById('assistant-usage');
+     const assistantFileInput = document.getElementById('assistant-file');
+     const assistantAttachments = document.getElementById('assistant-attachments');
+     const assistantDropzone = document.getElementById('assistant-dropzone');
+     const assistantModelSelect = document.getElementById('assistant-model');
+     let assistantHistory = [];
+     let pendingAttachments = [];
 
-    function updateInfoPanel(){
-      const cur=vesselData.currentVoyageId||'N/A';
-      infoPanel.innerHTML =
-        `<h3 class="text-2xl font-bold text-cyan-400">${vesselData.name}</h3>
-         <p class="text-sm text-slate-400">IMO: ${vesselData.imo} / MMSI: ${vesselData.mmsi}</p>
-         <div class="mt-4 space-y-2">
-           <div><strong>Current Voyage:</strong> <span class="font-mono text-lg">${cur}</span></div>
-           <div><strong>Status:</strong> <span class="font-mono text-lg text-yellow-300">${vesselData.status}</span></div>
+     function updateInfoPanel(){
+       const cur=vesselData.currentVoyageId||'N/A';
+       const activeLeg = voyageSchedule.find(v=>v.id===vesselData.currentVoyageId);
+       const progressRatio = clamp(vesselData.progress ?? 0,0,1);
+       const progressPct = progressRatio * 100;
+       const etdDisplay = activeLeg?.etd ? toLocal(activeLeg.etd) : 'N/A';
+       const etaDisplay = activeLeg?.eta ? toLocal(activeLeg.eta) : 'N/A';
+       infoPanel.innerHTML =
+         `<div class="flex items-start justify-between gap-3">
+            <div>
+              <h3 class="text-2xl font-bold text-cyan-400">${vesselData.name}</h3>
+              <p class="text-sm text-slate-400">IMO: ${vesselData.imo} / MMSI: ${vesselData.mmsi}</p>
+            </div>
+            <span class="px-2 py-1 rounded-md text-xs bg-slate-800/80 border border-slate-600">${tz}</span>
+          </div>
+          <div class="grid grid-cols-2 gap-3 text-sm">
+            <div class="bg-slate-800/60 border border-slate-700 rounded-lg p-3">
+              <p class="text-slate-400 text-xs uppercase tracking-wider">Current Voyage</p>
+              <p class="mt-1 font-mono text-lg text-emerald-300">${cur}</p>
+            </div>
+            <div class="bg-slate-800/60 border border-slate-700 rounded-lg p-3">
+              <p class="text-slate-400 text-xs uppercase tracking-wider">Status</p>
+              <p class="mt-1 font-semibold text-sky-300">${vesselData.status}</p>
+            </div>
+          </div>
+          <div class="bg-slate-800/60 border border-slate-700 rounded-lg p-3">
+            <div class="flex items-center justify-between text-xs text-slate-400">
+              <span>Leg Progress</span>
+              <span class="font-mono text-slate-200">${progressPct.toFixed(2)}%</span>
+           </div>
+           <div class="w-full h-2 bg-slate-900/80 rounded-full mt-2">
+             <div class="h-2 rounded-full bg-gradient-to-r from-cyan-400 via-sky-500 to-emerald-400" style="width:${Math.min(100,Math.max(0,progressPct)).toFixed(2)}%"></div>
+           </div>
+           <div class="mt-3 grid grid-cols-2 gap-2 text-xs text-slate-400">
+             <div>
+               <span class="block uppercase tracking-wide">ETD</span>
+               <span class="font-mono text-slate-200">${etdDisplay}</span>
+             </div>
+             <div>
+               <span class="block uppercase tracking-wide">ETA</span>
+               <span class="font-mono text-slate-200">${etaDisplay}</span>
+             </div>
+           </div>
          </div>`;
-    }
+     }
 
-    async function renderSchedule(){
-      const scheduleBody = document.getElementById('schedule-body');
-      if (!scheduleBody) return;
-      
-      document.getElementById('schedule-container').setAttribute('aria-busy','true');
-      scheduleBody.innerHTML = '';
-      
-      for (let index = 0; index < voyageSchedule.length; index += 1) {
-        const v = voyageSchedule[index];
-        let c="text-slate-300", pill="";
-        if(v.status==="In Transit") { c="text-blue-300"; pill='<span class="tag">Sailing</span>'; }
-        else if(v.status==="Delayed") { c="text-rose-300"; pill='<span class="tag">Delayed</span>'; }
-        else if(v.status==="Completed") { c="text-emerald-300"; pill='<span class="tag">Arrived</span>'; }
-        const hi=v.id===vesselData.currentVoyageId ? "row-current" : "";
-        
-        // Marine data for this port (simplified for current structure)
-        const snap = await updateMarineForLeg('Jebel Ali'); // Default port for now
-        const ioi = snap?.ioi ?? 50;
-        const decision = ioi >= 75 ? { tag: 'Go', tone: 'success' } : 
-                        ioi >= 55 ? { tag: 'Caution', tone: 'warn' } : 
-                        { tag: 'No-Go', tone: 'danger' };
-        
-        const row = document.createElement('tr');
-        row.id = `voyage-${v.id}`;
-        row.className = `border-t border-slate-700 ${hi}`;
-        row.setAttribute('role', 'row');
-        row.innerHTML = `
-          <td class="p-2 font-bold" role="gridcell" aria-describedby="th-voyage">${v.id}</td>
-          <td class="p-2" role="gridcell" aria-describedby="th-cargo">${v.cargo}</td>
-          <td class="p-2" role="gridcell" aria-describedby="th-etd">${toLocal(v.etd)}</td>
-          <td class="p-2" role="gridcell" aria-describedby="th-eta">${toLocal(v.eta)}</td>
-          <td class="p-2 ${c} font-semibold" role="gridcell" aria-describedby="th-status">${v.status} ${pill}</td>
-          <td class="p-2" role="gridcell" aria-describedby="th-ioi">${ioi}</td>
-          <td class="p-2" role="gridcell" aria-describedby="th-decision"><span class="pill ${decision.tone === 'danger' ? 'danger' : ''}">${decision.tag}</span></td>
-        `;
-        scheduleBody.appendChild(row);
-      }
-      
-      document.getElementById('schedule-container').setAttribute('aria-busy','false');
+     async function renderSchedule(){
+       const scheduleBody = document.getElementById('schedule-body');
+       if (!scheduleBody) return;
+       
+       document.getElementById('schedule-container').setAttribute('aria-busy','true');
+       scheduleBody.innerHTML = '';
+       
+       const marineSnap = await updateMarineForLeg('Jebel Ali');
+       const baseIoi = Number.isFinite(marineSnap?.ioi) ? Number(marineSnap.ioi) : 50;
 
-      if(vesselData.currentVoyageId){
-        const row=document.getElementById(`voyage-${vesselData.currentVoyageId}`);
-        if(row) row.scrollIntoView({block:'center',behavior:'smooth'});
-      }
-    }
+       for (let index = 0; index < voyageSchedule.length; index += 1) {
+         const v = voyageSchedule[index];
+         let c="text-slate-300", pill="";
+         if(v.status==="In Transit") { c="text-blue-300"; pill='<span class="tag">Sailing</span>'; }
+         else if(v.status==="Delayed") { c="text-rose-300"; pill='<span class="tag">Delayed</span>'; }
+         else if(v.status==="Completed") { c="text-emerald-300"; pill='<span class="tag">Arrived</span>'; }
+         const hi=v.id===vesselData.currentVoyageId ? "row-current" : "";
+
+         // Marine data for this port (simplified for current structure)
+         const ioi = baseIoi;
+         const decision = ioi >= 75 ? { tag: 'Go', tone: 'success' } :
+                         ioi >= 55 ? { tag: 'Caution', tone: 'warn' } :
+                         { tag: 'No-Go', tone: 'danger' };
+         const formattedIoi = Number.isFinite(ioi) ? Number(ioi).toFixed(2) : '50.00';
+
+         const row = document.createElement('tr');
+         row.id = `voyage-${v.id}`;
+         row.className = `border-t border-slate-700 ${hi}`;
+         row.setAttribute('role', 'row');
+         row.innerHTML = `
+           <td class="p-2 font-bold" role="gridcell" aria-describedby="th-voyage">${v.id}</td>
+           <td class="p-2" role="gridcell" aria-describedby="th-cargo">${v.cargo}</td>
+           <td class="p-2" role="gridcell" aria-describedby="th-etd">${toLocal(v.etd)}</td>
+           <td class="p-2" role="gridcell" aria-describedby="th-eta">${toLocal(v.eta)}</td>
+           <td class="p-2 ${c} font-semibold" role="gridcell" aria-describedby="th-status">${v.status} ${pill}</td>
+           <td class="p-2" role="gridcell" aria-describedby="th-ioi">${formattedIoi}</td>
+           <td class="p-2" role="gridcell" aria-describedby="th-decision"><span class="pill pill-${decision.tone}">${decision.tag}</span></td>
+         `;
+         scheduleBody.appendChild(row);
+       }
+       
+       document.getElementById('schedule-container').setAttribute('aria-busy','false');
+
+       if(vesselData.currentVoyageId){
+         const row=document.getElementById(`voyage-${vesselData.currentVoyageId}`);
+         if(row) row.scrollIntoView({block:'center',behavior:'smooth'});
+       }
+     }
 
     function setInfo(msgHtml, tone='info'){
       const color = tone==='warn' ? 'bg-yellow-900 border-yellow-500 text-yellow-100'
@@ -537,23 +599,57 @@
       reader.readAsText(f);
     });
 
-    weatherInput.addEventListener('change', (e)=>{
-      if(e.target.files.length===0) return;
-      const f = e.target.files[0];
+    weatherInput.addEventListener('change', async (event)=>{
+      const files = event.target.files || [];
+      if(files.length === 0) return;
+      const file = files[0];
+      const name = file.name || 'weather-file';
+      const isImage = (file.type && file.type.startsWith('image/')) || /\.(png|jpg|jpeg|webp|gif)$/i.test(name);
+
+      const busyClasses = ['bg-amber-500','hover:bg-amber-500','animate-pulse'];
+      const readyClasses = ['bg-emerald-600','hover:bg-emerald-700'];
+
+      if(isImage){
+        weatherLabel.textContent = 'Analyzing screenshot...';
+        weatherLabel.classList.remove(...readyClasses);
+        weatherLabel.classList.add(...busyClasses);
+        try{
+          const prompt = `You are an expert marine logistics AI. Analyze the attached weather report image named "${name}" and summarise the highest risk window, dominant hazards, and the expected schedule impact for JOPETWIL 71. Respond in Korean with bullet points.`;
+          const insight = await callAssistant(prompt, [file], { persist: false, historyOverride: [] });
+          analysisContent.innerHTML = insight.replace(/\n/g,'<br>');
+          aiAnalysisPanel.classList.remove('hidden');
+          setInfo('ADNOC 스크린샷 분석 완료. 리스크 모니터링이 활성화되었습니다.', 'warn');
+        }catch(err){
+          console.error(err);
+          aiAnalysisPanel.classList.add('hidden');
+          analysisContent.innerHTML = '';
+          setInfo(`⚠️ 스크린샷 분석 실패: ${err.message}`, 'danger');
+        }finally{
+          weatherLabel.classList.remove(...busyClasses);
+          weatherLabel.classList.add(...readyClasses);
+          weatherLabel.textContent = `Loaded: ${name}`;
+        }
+        return;
+      }
+
       const reader = new FileReader();
+      weatherLabel.classList.remove(...busyClasses);
+      weatherLabel.classList.add(...readyClasses);
       reader.onload = ()=>{
         try{
           const rows = parseCSV(reader.result);
           buildWeatherWindows(rows);
-          weatherLabel.textContent = `Loaded: ${f.name}`;
+          weatherLabel.textContent = `Loaded: ${name}`;
           weatherLinked = true;
+          aiAnalysisPanel.classList.add('hidden');
+          analysisContent.innerHTML = '';
           applyWeatherToSchedule();
         }catch(err){
           console.error(err);
           setInfo(`⚠️ 날씨 파일 오류: ${err.message}`, 'danger');
         }
       };
-      reader.readAsText(f);
+      reader.readAsText(file);
     });
 
     const briefingModal=document.getElementById('briefing-modal');
@@ -576,58 +672,129 @@
       el.setAttribute('aria-hidden', 'true');
       document.body.classList.remove('modal-open'); 
     }
-    [briefingModal,assistantModal].forEach(m=> m.addEventListener('click', e=>{ if(e.target===m) closeModal(m); }));
-    document.addEventListener('keydown', e=>{ if(e.key==='Escape'){ [briefingModal,assistantModal].forEach(closeModal); } });
+     [briefingModal,assistantModal].forEach(m=> m.addEventListener('click', e=>{ if(e.target===m) closeModal(m); }));
+     document.addEventListener('keydown', e=>{ if(e.key==='Escape'){ [briefingModal,assistantModal].forEach(closeModal); } });
 
-    function renderAttachmentList(){
-      if(pendingAttachments.length===0){
-        assistantAttachments.innerHTML = '<div class="text-slate-500">No attachments selected.</div>';
-        return;
-      }
-      assistantAttachments.innerHTML = pendingAttachments.map((file,idx)=>{
-        return `<div class="flex justify-between items-center bg-slate-900/80 px-2 py-1 rounded">
-                  <span class="truncate max-w-[14rem]">${file.name}</span>
-                  <button data-index="${idx}" class="text-rose-300 hover:text-rose-400 remove-attachment">Remove</button>
-                </div>`;
-      }).join('');
-      assistantAttachments.querySelectorAll('.remove-attachment').forEach(btn=>{
-        btn.addEventListener('click',(ev)=>{
-          const idx = Number(ev.target.getAttribute('data-index'));
-          pendingAttachments.splice(idx,1);
-          renderAttachmentList();
-        });
-      });
-    }
+     function guessExtension(type){
+       if(!type) return '';
+       if(type.includes('png')) return '.png';
+       if(type.includes('jpeg') || type.includes('jpg')) return '.jpg';
+       if(type.includes('gif')) return '.gif';
+       if(type.includes('webp')) return '.webp';
+       if(type.includes('pdf')) return '.pdf';
+       if(type.includes('csv')) return '.csv';
+       if(type.includes('plain')) return '.txt';
+       return '';
+     }
 
-    assistantAttachments.innerHTML = '<div class="text-slate-500">No attachments selected.</div>';
+     function addAttachmentsFromFileList(fileList){
+       const files = Array.from(fileList || []);
+       if(files.length===0) return;
+       const stamped = files.map((file,idx)=>{
+         if(file.name) return file;
+         const ext = guessExtension(file.type || '');
+         const timestamp = new Date().toISOString().replace(/[.:]/g,'-');
+         return new File([file], `capture-${timestamp}-${idx+1}${ext}`, { type: file.type || 'application/octet-stream' });
+       });
+       pendingAttachments = pendingAttachments.concat(stamped);
+       renderAttachmentList();
+     }
+
+     function renderAttachmentList(){
+       if(pendingAttachments.length===0){
+         assistantAttachments.innerHTML = '<div class="text-slate-500 text-[11px]">첨부된 파일이 없습니다. 스크린 캡처 붙여넣기를 지원합니다.</div>';
+         return;
+       }
+       assistantAttachments.innerHTML = pendingAttachments.map((file,idx)=>{
+         const isImage = (file.type || '').startsWith('image/');
+         const preview = isImage
+           ? `<img src="${URL.createObjectURL(file)}" alt="${file.name} preview" class="w-12 h-12 object-cover rounded-md border border-slate-700" onload="URL.revokeObjectURL(this.src)">`
+           : `<span class="w-12 h-12 flex items-center justify-center rounded-md bg-slate-900/70 border border-slate-700 text-lg">📄</span>`;
+         const sizeKb = file.size ? (file.size/1024).toFixed(2) : '0.00';
+         return `<div class="flex items-center gap-3 bg-slate-900/70 px-3 py-2 rounded-lg border border-slate-800/70">
+                   ${preview}
+                   <div class="flex-1 min-w-0">
+                     <p class="text-slate-200 text-sm truncate">${file.name}</p>
+                     <p class="text-slate-500 text-[11px]">${file.type || 'unknown'} • ${sizeKb} KB</p>
+                   </div>
+                   <button data-index="${idx}" class="text-rose-300 hover:text-rose-200 text-xs remove-attachment">Remove</button>
+                 </div>`;
+       }).join('');
+       assistantAttachments.querySelectorAll('.remove-attachment').forEach(btn=>{
+         btn.addEventListener('click',(ev)=>{
+           const idx = Number(ev.currentTarget.getAttribute('data-index'));
+           pendingAttachments.splice(idx,1);
+           renderAttachmentList();
+         });
+       });
+     }
+
+    renderAttachmentList();
 
     document.getElementById('assistant-attach-btn').addEventListener('click', ()=> assistantFileInput.click());
     assistantFileInput.addEventListener('change', (event)=>{
-      pendingAttachments = Array.from(event.target.files || []);
-      renderAttachmentList();
+      addAttachmentsFromFileList(event.target.files || []);
+      assistantFileInput.value = '';
+    });
+
+    ['dragenter','dragover'].forEach(evt=>{
+      assistantDropzone.addEventListener(evt,(event)=>{
+        event.preventDefault();
+        assistantDropzone.classList.add('drop-active');
+      });
+    });
+    ['dragleave','dragend'].forEach(evt=>{
+      assistantDropzone.addEventListener(evt,()=>{
+        assistantDropzone.classList.remove('drop-active');
+      });
+    });
+    assistantDropzone.addEventListener('drop',(event)=>{
+      event.preventDefault();
+      assistantDropzone.classList.remove('drop-active');
+      addAttachmentsFromFileList(event.dataTransfer?.files || []);
+    });
+
+    document.addEventListener('paste',(event)=>{
+      if(assistantModal.getAttribute('aria-hidden') === 'true') return;
+      const items = event.clipboardData?.items || [];
+      const files = [];
+      for(const item of items){
+        if(item.kind === 'file'){
+          const file = item.getAsFile();
+          if(file) files.push(file);
+        }
+      }
+      if(files.length){
+        event.preventDefault();
+        addAttachmentsFromFileList(files);
+      }
     });
 
     document.getElementById('assistant-reset').addEventListener('click', ()=>{
       assistantHistory = [];
-      assistantConversation.innerHTML = '<div class="text-slate-400">무엇을 도와드릴까요? (예: “다음 3일 스케줄 요약”)</div>';
+      assistantConversation.innerHTML = '<div class="text-slate-400">무엇을 도와드릴까요? (예: "다음 3일 스케줄 요약")<br/>첨부 버튼으로 캡처/문서를 추가하면 자동 분석됩니다.</div>';
       assistantUsage.textContent='';
+      pendingAttachments = [];
+      renderAttachmentList();
     });
 
-    async function callAssistant(prompt, attachments){
+    async function callAssistant(prompt, attachments, options = {}){
+      const { persist = true, historyOverride = assistantHistory, model = assistantModelSelect.value } = options;
       const formData = new FormData();
       formData.append('prompt', prompt);
-      formData.append('history', JSON.stringify(assistantHistory));
-      formData.append('model', assistantModelSelect.value);
-      attachments.forEach(file=> formData.append('files', file, file.name));
+      formData.append('history', JSON.stringify(historyOverride));
+      formData.append('model', model);
+      attachments.forEach(file=> formData.append('files', file, file.name || 'attachment'));
       const res = await fetch(`${API_BASE}/api/assistant`, { method:'POST', body: formData });
       if(!res.ok){
         const text = await res.text();
         throw new Error(text || 'Assistant call failed');
       }
       const data = await res.json();
-      assistantHistory.push({role:'user', content: prompt});
-      assistantHistory.push({role:'assistant', content: data.answer});
-      assistantUsage.textContent = `Last response model: ${assistantModelSelect.value}`;
+      if(persist){
+        assistantHistory = [...historyOverride, {role:'user', content: prompt}, {role:'assistant', content: data.answer}];
+        assistantUsage.textContent = `Last response model: ${model}`;
+      }
       return data.answer;
     }
 
@@ -648,7 +815,8 @@
           waveM: w.waveM,
           windKt: w.windKt,
           visKm: w.visKm
-        }))
+        })),
+        model: assistantModelSelect.value
       };
       try{
         const res = await fetch(`${API_BASE}/api/briefing`, {
@@ -671,7 +839,7 @@
       const prompt = `다음 일정과 기상창을 기반으로 3가지 위험 시나리오와 대응 권고를 bullet로 정리해줘.\n일정: ${JSON.stringify(voyageSchedule)}\n기상: ${JSON.stringify(weatherWindows)}`;
       setInfo('AI 위험 스캔 실행 중...', 'info');
       try{
-        const answer = await callAssistant(prompt, []);
+        const answer = await callAssistant(prompt, [], { persist: false });
         setInfo(answer.replace(/\n/g,'<br>'), 'warn');
       }catch(err){
         setInfo(`AI 위험 스캔 실패: ${err.message}`, 'danger');
@@ -711,17 +879,36 @@
       setInfo('시뮬레이션 시계가 초기화되었습니다.');
     });
 
-    // Marine data functions
-    async function updateMarineForLeg(portName) {
-      // 워커로 오프로드
-      const snap = await fetchMarineAndIOIInWorker(portName);
-      if (snap && snap.hs != null && snap.windKt != null) {
-        marineBadge.textContent = `Hs: ${snap.hs.toFixed(2)} m · Wind: ${Math.round(snap.windKt)} kt`;
-      } else {
-        marineBadge.textContent = `Marine: n/a`;
-      }
-      return snap;
-    }
+     // Marine data functions
+     function applyMarineBadge(snap) {
+       const badge = document.getElementById('marineBadge');
+       badge.classList.remove('pill-success','pill-warn','pill-danger');
+       let tone = 'warn';
+       if (snap && typeof snap.ioi === 'number') {
+         if (snap.ioi >= 75) tone = 'success';
+         else if (snap.ioi < 55) tone = 'danger';
+       }
+       badge.classList.add(`pill-${tone}`);
+       if (snap && snap.hs != null && snap.windKt != null) {
+         badge.textContent = `Hs: ${snap.hs.toFixed(2)} m · Wind: ${snap.windKt.toFixed(2)} kt`;
+       } else {
+         badge.textContent = `Marine: n/a`;
+       }
+     }
+
+     async function updateMarineForLeg(portName) {
+       const now = Date.now();
+       const cached = marineSnapshotCache.get(portName);
+       if (cached && (now - cached.timestamp) < MARINE_CACHE_TTL_MS) {
+         applyMarineBadge(cached.snap);
+         return cached.snap;
+       }
+       // 워커로 오프로드
+       const snap = await fetchMarineAndIOIInWorker(portName);
+       marineSnapshotCache.set(portName, { snap, timestamp: now });
+       applyMarineBadge(snap);
+       return snap;
+     }
 
     // ===== Worker 생성 (Blob URL) : IOI 계산 + Marine fetch 오프로드 =====
     const workerCode = `

--- a/logistics_control_tower_v2.html
+++ b/logistics_control_tower_v2.html
@@ -1,0 +1,796 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Logistics Control Tower v2.5</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" crossorigin=""/>
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" crossorigin=""></script>
+  <style>
+    body{background:#0f172a;color:#e2e8f0;font-family:'Segoe UI',sans-serif}
+    .leaflet-container{background:#1f2937;border-radius:.75rem}
+    .leaflet-tooltip{background:rgba(15,23,42,.95);color:#fff;border:1px solid #475569;box-shadow:none;font-weight:600;padding:4px 8px}
+    .scrollbar-hide::-webkit-scrollbar{display:none}.scrollbar-hide{-ms-overflow-style:none;scrollbar-width:none}
+    .modal{transition:opacity .25s ease;z-index:10000}
+    body.modal-open{overflow:hidden}
+    #map{position:relative;z-index:0}
+    .leaflet-tooltip,.leaflet-popup{z-index:500!important}
+    .row-current{background:rgba(59,130,246,.15)}
+    .kbd{border:1px solid #475569;border-bottom-width:2px;border-radius:.375rem;padding:.15rem .35rem;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+    .tag{font-size:.75rem;padding:.1rem .4rem;border:1px solid #475569;border-radius:.5rem}
+    .chip{display:inline-flex;align-items:center;gap:.25rem;padding:.25rem .5rem;border-radius:.5rem;background:rgba(79,70,229,.2);color:#c7d2fe;font-size:.75rem}
+    .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+    .btn { min-height: 44px; min-width: 44px; } /* 터치 타겟 44px 기준 */
+
+    @media (prefers-contrast: more) {
+        :root {
+            --accent: #00b4ff;
+            --text: #ffffff;
+            --muted: #e2e8f0;
+        }
+        .panel, .status-card, .control-card { border-color: rgba(255,255,255,0.6); }
+        .pill { background: rgba(0,180,255,0.25); }
+    }
+  </style>
+</head>
+<body class="p-4">
+  <!-- Skip link for keyboard users -->
+  <a href="#main" class="sr-only" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;"
+     onfocus="this.style.position='static';this.style.width='auto';this.style.height='auto';this.style.padding='0.5rem 0.75rem';this.style.background='#0ea5e9';this.style.color='#000';this.style.borderRadius='8px';">
+     Skip to main content
+  </a>
+  <main id="main" class="grid grid-cols-1 lg:grid-cols-5 gap-4 h-[95vh]" role="main" aria-live="polite">
+    <div id="map" class="lg:col-span-3 rounded-xl shadow-xl border border-slate-700 h-full min-h-[400px]" 
+         role="img" aria-label="Vessel tracking map showing route from MW4 to AGI" tabindex="0"></div>
+
+    <aside class="lg:col-span-2 flex flex-col gap-4 h-full" role="complementary" aria-label="Vessel control and schedule information">
+      <div id="info-panel" class="bg-slate-900 p-4 rounded-xl shadow-lg border border-slate-700">
+        <div class="flex items-center justify-between">
+          <h2 class="text-xl font-bold border-b border-slate-600 pb-2 mb-3">Vessel Control</h2>
+          <div class="flex items-center gap-2">
+            <span class="tag">Local: Asia/Dubai</span>
+            <div class="pill" id="marineBadge" title="Marine snapshot">Hs: -- m · Wind: -- kt</div>
+          </div>
+        </div>
+        <div id="vessel-info"><p class="text-slate-400">Loading vessel data...</p></div>
+
+        <div class="grid grid-cols-2 gap-2 mt-4">
+          <button id="briefing-btn" class="w-full bg-indigo-600 hover:bg-indigo-700 text-white font-bold py-2 px-3 rounded-lg transition-colors flex items-center justify-center gap-2 text-sm"
+                  aria-describedby="briefing-desc">✨ Daily Briefing</button>
+          <button id="assistant-btn" class="w-full bg-purple-600 hover:bg-purple-700 text-white font-bold py-2 px-3 rounded-lg transition-colors flex items-center justify-center gap-2 text-sm"
+                  aria-describedby="assistant-desc">🤖 Ask AI Assistant</button>
+        </div>
+        <div class="sr-only" id="briefing-desc">Generate AI-powered daily logistics briefing</div>
+        <div class="sr-only" id="assistant-desc">Open AI assistant chat for logistics questions</div>
+
+        <div class="mt-4 grid grid-cols-2 gap-2">
+          <label class="w-full">
+            <input type="file" id="file-schedule" class="hidden" accept=".csv,.json"/>
+            <span id="label-schedule" class="w-full inline-flex items-center justify-center bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-3 rounded-lg cursor-pointer">Upload Schedule (CSV/JSON)</span>
+          </label>
+          <label class="w-full">
+            <input type="file" id="file-weather" class="hidden" accept=".csv"/>
+            <span id="label-weather" class="w-full inline-flex items-center justify-center bg-emerald-600 hover:bg-emerald-700 text-white font-bold py-2 px-3 rounded-lg cursor-pointer">Upload Weather (CSV)</span>
+          </label>
+        </div>
+        <p class="mt-3 text-xs text-slate-400">Tips: Press <span class="kbd">Esc</span> to close modals. 파일 포맷은 하단 가이드를 참고. API는 <span class="chip" id="api-status">API: Offline</span></p>
+      </div>
+
+      <div class="bg-slate-900 p-4 rounded-xl shadow-lg border border-slate-700 flex-grow flex flex-col h-1/2">
+        <div class="flex items-center justify-between border-b border-slate-600 pb-2 mb-3">
+          <h2 class="text-xl font-bold">Full Voyage Schedule</h2>
+          <span id="linkage-badge" class="tag" aria-live="polite">Linked to Weather: OFF</span>
+        </div>
+        <div id="schedule-container" class="overflow-y-auto scrollbar-hide flex-grow" aria-busy="false" role="region" aria-label="Voyage schedule table">
+          <table class="w-full text-left text-sm" role="table" aria-describedby="schedule-caption">
+            <caption id="schedule-caption" class="sr-only">Voyage schedule with ETD, ETA, cargo, and status information</caption>
+            <thead class="sticky top-0 bg-slate-900">
+              <tr role="row">
+                <th scope="col" id="th-voyage" role="columnheader">Voyage</th>
+                <th scope="col" id="th-cargo" role="columnheader">Cargo</th>
+                <th scope="col" id="th-etd" role="columnheader">ETD</th>
+                <th scope="col" id="th-eta" role="columnheader">ETA</th>
+                <th scope="col" id="th-status" role="columnheader">Status</th>
+                <th scope="col" id="th-ioi" role="columnheader">IOI (0–100)</th>
+                <th scope="col" id="th-decision" role="columnheader">Go/No-Go</th>
+              </tr>
+            </thead>
+            <tbody id="schedule-body" role="rowgroup"></tbody>
+          </table>
+        </div>
+      </div>
+
+      <div id="risk-panel" class="bg-slate-900 p-4 rounded-xl shadow-lg border border-slate-700" role="region" aria-label="Risk simulation and control">
+        <div class="flex items-center justify-between">
+          <h2 class="text-xl font-bold border-b border-slate-600 pb-2 mb-3">Risk Simulation & Control</h2>
+          <button id="btn-ai-risk" class="text-xs bg-rose-600 hover:bg-rose-700 text-white px-3 py-1 rounded-md transition"
+                  aria-describedby="risk-scan-desc">AI Risk Scan</button>
+        </div>
+        <div class="flex items-center justify-between gap-3">
+          <p id="sim-time" class="text-lg font-mono" aria-live="polite" aria-label="Current simulation time"></p>
+          <div class="flex items-center gap-2">
+            <button id="btn-reset" class="bg-slate-700 hover:bg-slate-600 text-white text-sm px-3 py-2 rounded"
+                    aria-describedby="reset-desc">Reset Sim</button>
+            <span class="tag" id="sim-speed" aria-live="polite" aria-label="Simulation speed multiplier">×4.00</span>
+          </div>
+        </div>
+        <div id="alert-container" class="mt-4" role="alert" aria-live="polite" aria-atomic="false">
+          <p class="text-green-400">✅ 시스템 정상. 활성 위험 없음.</p>
+        </div>
+        <div class="sr-only" id="risk-scan-desc">Run AI-powered risk analysis on current voyage schedule</div>
+        <div class="sr-only" id="reset-desc">Reset simulation to initial state</div>
+      </div>
+    </div>
+  </div>
+
+  <div id="briefing-modal" class="modal fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center p-4 opacity-0 pointer-events-none"
+       role="dialog" aria-modal="true" aria-labelledby="modal-title" aria-describedby="modal-content" aria-hidden="true">
+    <div class="bg-slate-900 rounded-xl shadow-2xl p-6 w-full max-w-lg border border-slate-700" role="document">
+      <h2 id="modal-title" class="text-2xl font-bold text-indigo-400 mb-4">✨ AI-Generated Output</h2>
+      <div id="modal-content" class="text-slate-300 bg-slate-950 p-4 rounded-md min-h-[150px] whitespace-pre-line overflow-y-auto max-h-[60vh]"></div>
+      <button id="close-modal-btn" class="mt-6 w-full bg-slate-700 hover:bg-slate-600 text-white font-bold py-2 px-4 rounded-lg transition-colors">Close</button>
+    </div>
+  </div>
+
+  <div id="assistant-modal" class="modal fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center p-4 opacity-0 pointer-events-none"
+       role="dialog" aria-modal="true" aria-labelledby="assistant-title" aria-describedby="assistant-conversation" aria-hidden="true">
+    <div class="bg-slate-900 rounded-xl shadow-2xl p-6 w-full max-w-2xl border border-slate-700 flex flex-col h-[80vh]" role="document">
+      <div class="flex items-center justify-between mb-4">
+        <h2 id="assistant-title" class="text-2xl font-bold text-purple-400">🤖 AI Logistics Assistant</h2>
+        <div class="flex items-center gap-2">
+          <label class="text-xs text-slate-300">Model
+            <select id="assistant-model" class="ml-2 bg-slate-800 border border-slate-600 text-slate-100 text-xs rounded px-2 py-1">
+              <option value="gpt-4.1-mini">gpt-4.1-mini</option>
+              <option value="gpt-4o-mini">gpt-4o-mini</option>
+            </select>
+          </label>
+        </div>
+      </div>
+      <div id="assistant-conversation" class="flex-grow bg-slate-950 p-4 rounded-md overflow-y-auto scrollbar-hide space-y-2 text-sm">
+        <div class="text-slate-400">무엇을 도와드릴까요? (예: “다음 3일 스케줄 요약”)<br/>첨부 버튼으로 캡처/문서를 추가하면 자동 분석됩니다.</div>
+      </div>
+      <div class="mt-3 bg-slate-800/60 border border-slate-600 rounded-lg p-3">
+        <div class="flex items-center justify-between">
+          <div class="text-xs text-slate-300 font-semibold">Attachments</div>
+          <button id="assistant-attach-btn" class="text-xs bg-slate-700 hover:bg-slate-600 text-white px-2 py-1 rounded">+ Add</button>
+        </div>
+        <input type="file" id="assistant-file" class="hidden" accept="image/*,.pdf,.txt,.csv" multiple />
+        <div id="assistant-attachments" class="mt-2 text-xs text-slate-400 space-y-1"></div>
+      </div>
+      <form id="assistant-form" class="mt-3 flex gap-2" role="form" aria-label="AI Assistant Chat">
+        <input type="text" id="assistant-input" class="flex-grow bg-slate-800 text-white rounded-lg p-2 border border-slate-600 focus:outline-none focus:ring-2 focus:ring-purple-500" 
+               placeholder="Ask a question..." aria-label="Type your question here" aria-describedby="assistant-input-desc">
+        <button type="submit" class="bg-purple-600 hover:bg-purple-700 text-white font-bold py-2 px-4 rounded-lg transition-colors"
+                aria-label="Send message">Send</button>
+      </form>
+      <div class="sr-only" id="assistant-input-desc">Type your logistics question and press Enter or click Send</div>
+      <div class="flex gap-2 mt-2 text-xs text-slate-400">
+        <button id="assistant-reset" type="button" class="px-3 py-1 rounded bg-slate-700 hover:bg-slate-600 text-white">Clear Chat</button>
+        <span id="assistant-usage" class="italic"></span>
+      </div>
+      <button id="close-assistant-btn" class="mt-3 w-full bg-slate-700 hover:bg-slate-600 text-white font-bold py-2 px-4 rounded-lg transition-colors">Close</button>
+    </div>
+  </div>
+
+  <script>
+    // requestIdleCallback 폴리필 (간단)
+    window.requestIdleCallback ||= (cb)=>setTimeout(()=>cb({didTimeout:false,timeRemaining:()=>0}), 1);
+    window.cancelIdleCallback ||= (id)=>clearTimeout(id);
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const API_BASE = window.APP_CONFIG?.apiBase ?? 'http://localhost:8000';
+    const tz = 'Asia/Dubai';
+    
+    // Scenario presets and port coordinates
+    const scenarioPresets = {
+      base:        { delayOnRisk: 4.0,  hs_caution: 1.50, hs_nogo: 2.50, wind_caution: 18, wind_nogo: 28 },
+      weather:     { delayOnRisk: 6.0,  hs_caution: 1.20, hs_nogo: 2.00, wind_caution: 16, wind_nogo: 24 },
+      congestion:  { delayOnRisk: 5.0,  hs_caution: 1.60, hs_nogo: 2.60, wind_caution: 20, wind_nogo: 30 },
+      inspection:  { delayOnRisk: 3.5, hs_caution: 1.80, hs_nogo: 2.80, wind_caution: 22, wind_nogo: 32 }
+    };
+    const RULE = scenarioPresets.base;
+    
+    const portCoords = {
+      'Shanghai':   { lat: 31.2304, lon: 121.4737 },
+      'Singapore':  { lat: 1.3521,  lon: 103.8198 },
+      'Colombo':    { lat: 6.9271,  lon: 79.8612  },
+      'Jebel Ali':  { lat: 25.006,  lon: 55.065   }
+    };
+    const fmtIso = (d)=> new Date(d).toISOString();
+    const toLocal = (d)=> new Date(d).toLocaleString('en-GB',{ timeZone: tz, dateStyle:'short', timeStyle:'medium' });
+    const pad2 = (n)=> String(n).padStart(2,'0');
+    const clamp = (v,min,max)=> Math.max(min, Math.min(max,v));
+    const parseNum = (s)=> Number(String(s||'').trim());
+    const parseISO = (s)=> {
+      if(!s) return null;
+      const t = String(s).trim().replace(' ', 'T');
+      return isNaN(Date.parse(t)) ? null : new Date(t);
+    };
+    const parseCSV = (text)=>{
+      const lines = text.trim().split(/\r?\n/);
+      const header = lines.shift().split(',').map(h=>h.trim());
+      return lines.map(line=>{
+        const cells = line.split(',').map(c=>c.trim());
+        const obj={};
+        header.forEach((h,i)=> obj[h]=cells[i]);
+        return obj;
+      });
+    };
+
+    async function checkApiHealth(){
+      const badge = document.getElementById('api-status');
+      try{
+        const res = await fetch(`${API_BASE}/health`);
+        if(res.ok){
+          badge.textContent = 'API: Online';
+          badge.classList.remove('bg-rose-500/40');
+          badge.classList.add('bg-emerald-500/40','text-emerald-200');
+        }else{
+          throw new Error('Healthcheck failed');
+        }
+      }catch(err){
+        badge.textContent = 'API: Offline';
+        badge.classList.remove('bg-emerald-500/40','text-emerald-200');
+        badge.classList.add('bg-rose-500/40');
+      }
+    }
+
+    checkApiHealth();
+
+    const map = L.map('map').setView([24.7, 54.1], 8);
+    L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {maxZoom:19, attribution:'&copy; OpenStreetMap & CARTO'}).addTo(map);
+
+    const vesselIcon = L.icon({iconUrl:'https://i.imgur.com/G4Am98f.png', iconSize:[35,35]});
+    const vesselData = {
+      name:"JOPETWIL 71", imo:"9582829", mmsi:"470486000",
+      route:[
+        [24.3400,54.4500], [24.4300,54.4300], [24.4700,54.3900],
+        [24.5600,54.2000], [24.6500,54.0000], [24.8500,53.8000],
+        [24.9500,53.7400], [24.9500,53.3000], [25.0200,53.0600],
+        [24.8400,53.6500]
+      ],
+      marker:L.marker([24.34,54.45],{icon:vesselIcon})
+              .bindTooltip("JOPETWIL 71",{permanent:true,direction:'top',offset:[0,-18],className:'leaflet-tooltip'}),
+      routePolyline:null,
+      progress:0.00,
+      status:"Loading @ MW4",
+      currentVoyageId:null
+    };
+    vesselData.marker.addTo(map);
+    vesselData.routePolyline = L.polyline(vesselData.route, {color:'#FBBF24', weight:3, dashArray:'5,10'}).addTo(map);
+    map.fitBounds(vesselData.routePolyline.getBounds(), {padding:[20,20]});
+
+    let currentSimDate = new Date("2025-09-28T12:00:00Z");
+    let speedFactor = 240;
+    let weatherLinked = false;
+    const simSpeedBadge = document.getElementById('sim-speed');
+    const linkageBadge = document.getElementById('linkage-badge');
+    simSpeedBadge.textContent = '×4.00';
+
+    let voyageSchedule = [
+      { id:"69th", cargo:"Dune Sand",  etd:"2025-09-28T16:00:00Z", eta:"2025-09-29T04:00:00Z", status:"Scheduled" },
+      { id:"70th", cargo:"10mm Agg.",  etd:"2025-09-30T16:00:00Z", eta:"2025-10-01T04:00:00Z", status:"Scheduled" },
+      { id:"71st", cargo:"5mm Agg.",   etd:"2025-10-02T16:00:00Z", eta:"2025-10-03T04:00:00Z", status:"Scheduled" }
+    ];
+
+    let weatherWindows = [];
+
+    const R=6371e3, toRad=d=>d*Math.PI/180;
+    function haversine(a,b){
+      const [lat1,lon1]=a,[lat2,lon2]=b;
+      const dLat=toRad(lat2-lat1), dLon=toRad(lon2-lon1);
+      const phi1=toRad(lat1), phi2=toRad(lat2);
+      const h=Math.sin(dLat/2)**2 + Math.cos(phi1)*Math.cos(phi2)*Math.sin(dLon/2)**2;
+      return 2*R*Math.asin(Math.sqrt(h));
+    }
+    const segments=[]; let totalMeters=0;
+    for(let i=0;i<vesselData.route.length-1;i++){
+      const a=vesselData.route[i], b=vesselData.route[i+1];
+      const m=haversine(a,b);
+      segments.push({a,b,m,accStart:totalMeters,accEnd:totalMeters+m});
+      totalMeters+=m;
+    }
+    function interpolateOnRoute(progress){
+      const target=clamp(progress,0,1)*totalMeters;
+      const seg=segments.find(s=>target>=s.accStart && target<=s.accEnd) || segments[segments.length-1];
+      const t=(target-seg.accStart)/(seg.m||1);
+      const lat=seg.a[0]+(seg.b[0]-seg.a[0])*t;
+      const lon=seg.a[1]+(seg.b[1]-seg.a[1])*t;
+      return [Number(lat.toFixed(5)), Number(lon.toFixed(5))];
+    }
+
+    const infoPanel = document.getElementById('vessel-info');
+    const timeDisplay = document.getElementById('sim-time');
+    const scheduleContainer = document.getElementById('schedule-container');
+    const alertContainer = document.getElementById('alert-container');
+    const assistantConversation = document.getElementById('assistant-conversation');
+    const assistantUsage = document.getElementById('assistant-usage');
+    const assistantFileInput = document.getElementById('assistant-file');
+    const assistantAttachments = document.getElementById('assistant-attachments');
+    const assistantModelSelect = document.getElementById('assistant-model');
+    let assistantHistory = [];
+    let pendingAttachments = [];
+
+    function updateInfoPanel(){
+      const cur=vesselData.currentVoyageId||'N/A';
+      infoPanel.innerHTML =
+        `<h3 class="text-2xl font-bold text-cyan-400">${vesselData.name}</h3>
+         <p class="text-sm text-slate-400">IMO: ${vesselData.imo} / MMSI: ${vesselData.mmsi}</p>
+         <div class="mt-4 space-y-2">
+           <div><strong>Current Voyage:</strong> <span class="font-mono text-lg">${cur}</span></div>
+           <div><strong>Status:</strong> <span class="font-mono text-lg text-yellow-300">${vesselData.status}</span></div>
+         </div>`;
+    }
+
+    async function renderSchedule(){
+      const scheduleBody = document.getElementById('schedule-body');
+      if (!scheduleBody) return;
+      
+      document.getElementById('schedule-container').setAttribute('aria-busy','true');
+      scheduleBody.innerHTML = '';
+      
+      for (let index = 0; index < voyageSchedule.length; index += 1) {
+        const v = voyageSchedule[index];
+        let c="text-slate-300", pill="";
+        if(v.status==="In Transit") { c="text-blue-300"; pill='<span class="tag">Sailing</span>'; }
+        else if(v.status==="Delayed") { c="text-rose-300"; pill='<span class="tag">Delayed</span>'; }
+        else if(v.status==="Completed") { c="text-emerald-300"; pill='<span class="tag">Arrived</span>'; }
+        const hi=v.id===vesselData.currentVoyageId ? "row-current" : "";
+        
+        // Marine data for this port (simplified for current structure)
+        const snap = await updateMarineForLeg('Jebel Ali'); // Default port for now
+        const ioi = snap?.ioi ?? 50;
+        const decision = ioi >= 75 ? { tag: 'Go', tone: 'success' } : 
+                        ioi >= 55 ? { tag: 'Caution', tone: 'warn' } : 
+                        { tag: 'No-Go', tone: 'danger' };
+        
+        const row = document.createElement('tr');
+        row.id = `voyage-${v.id}`;
+        row.className = `border-t border-slate-700 ${hi}`;
+        row.setAttribute('role', 'row');
+        row.innerHTML = `
+          <td class="p-2 font-bold" role="gridcell" aria-describedby="th-voyage">${v.id}</td>
+          <td class="p-2" role="gridcell" aria-describedby="th-cargo">${v.cargo}</td>
+          <td class="p-2" role="gridcell" aria-describedby="th-etd">${toLocal(v.etd)}</td>
+          <td class="p-2" role="gridcell" aria-describedby="th-eta">${toLocal(v.eta)}</td>
+          <td class="p-2 ${c} font-semibold" role="gridcell" aria-describedby="th-status">${v.status} ${pill}</td>
+          <td class="p-2" role="gridcell" aria-describedby="th-ioi">${ioi}</td>
+          <td class="p-2" role="gridcell" aria-describedby="th-decision"><span class="pill ${decision.tone === 'danger' ? 'danger' : ''}">${decision.tag}</span></td>
+        `;
+        scheduleBody.appendChild(row);
+      }
+      
+      document.getElementById('schedule-container').setAttribute('aria-busy','false');
+
+      if(vesselData.currentVoyageId){
+        const row=document.getElementById(`voyage-${vesselData.currentVoyageId}`);
+        if(row) row.scrollIntoView({block:'center',behavior:'smooth'});
+      }
+    }
+
+    function setInfo(msgHtml, tone='info'){
+      const color = tone==='warn' ? 'bg-yellow-900 border-yellow-500 text-yellow-100'
+                   : tone==='danger' ? 'bg-rose-900 border-rose-500 text-rose-100'
+                   : 'bg-slate-950 border-slate-600 text-slate-200';
+      alertContainer.innerHTML = `<div class="${color} px-4 py-3 rounded border">${msgHtml}</div>`;
+    }
+
+    const LIM = {
+      waveWarnM: 1.75, waveNoGoM: 2.25,
+      windWarnKt: 24, windNoGoKt: 30,
+      visNoGoKm: 1.0
+    };
+
+    function buildWeatherWindows(rows){
+      weatherWindows = rows.map(r=>{
+        const start = parseISO(r.start);
+        const end   = parseISO(r.end);
+        const wv = parseNum(r.wave_m);
+        const wd = parseNum(r.wind_kt);
+        const vs = parseNum(r.vis_km);
+        let level = 'None';
+        if(isFinite(wv) && isFinite(wd) && isFinite(vs)){
+          if(wv >= LIM.waveNoGoM || wd >= LIM.windNoGoKt || vs <= LIM.visNoGoKm) level='NoGo';
+          else if(wv >= LIM.waveWarnM || wd >= LIM.windWarnKt) level='Warn';
+        }
+        return { start, end, level, waveM:wv, windKt:wd, visKm:vs };
+      }).filter(w => w.start && w.end);
+    }
+
+    function findWeatherLevelAt(dt){
+      const t = +dt;
+      const w = weatherWindows.find(win => t>= +win.start && t<= +win.end);
+      return w ? w.level : 'None';
+    }
+
+    function relHours(a,b){ return ( (+a)-(+b) )/36e5; }
+
+    function applyWeatherToSchedule(){
+      if(weatherWindows.length===0){ linkageBadge.textContent='Linked to Weather: OFF'; return; }
+      linkageBadge.textContent='Linked to Weather: ON';
+
+      voyageSchedule.sort((x,y)=> +new Date(x.etd) - +new Date(y.etd));
+
+      let lastETA = null;
+      let changes = [];
+
+      for(let i=0;i<voyageSchedule.length;i++){
+        const v = voyageSchedule[i];
+        let etd = new Date(v.etd);
+        let eta = new Date(v.eta);
+        if(lastETA && +etd < +lastETA){
+          const deltaH = Math.ceil(relHours(lastETA, etd));
+          etd = new Date(+etd + deltaH*36e5);
+          eta = new Date(+eta + deltaH*36e5);
+          changes.push(`${v.id}: shifted +${deltaH}h to keep sequence`);
+        }
+
+        const lvlAtETD = findWeatherLevelAt(etd);
+        const lvlAtETA = findWeatherLevelAt(eta);
+
+        if(lvlAtETD==='NoGo'){
+          etd = new Date(+etd + 24*36e5);
+          eta = new Date(+eta + 24*36e5);
+          v.status = 'Delayed';
+          changes.push(`${v.id}: ETD NoGo → +24h`);
+        }else if(lvlAtETA==='NoGo'){
+          eta = new Date(+eta + 12*36e5);
+          v.status = 'Delayed';
+          changes.push(`${v.id}: ETA NoGo → +12h`);
+        }
+
+        v.etd = fmtIso(etd);
+        v.eta = fmtIso(eta);
+        lastETA = eta;
+      }
+
+      if(changes.length){
+        setInfo(`<strong>Weather linked.</strong><br>${changes.map(c=>`• ${c}`).join('<br>')}`, 'warn');
+      }else{
+        setInfo('날씨 연동됨. 변경 사항 없음.');
+      }
+      renderSchedule();
+    }
+
+    function chooseActiveVoyage(now){
+      return voyageSchedule.find(v => v.status==="In Transit" || ((new Date(v.etd)<=now) && (v.status==="Scheduled" || v.status==="Delayed")));
+    }
+
+    function runSimulation(){
+      currentSimDate.setMinutes(currentSimDate.getMinutes() + (1 * speedFactor / 60));
+      timeDisplay.textContent = toLocal(currentSimDate);
+
+      let active = chooseActiveVoyage(currentSimDate);
+      if(active && vesselData.currentVoyageId!==active.id){
+        vesselData.currentVoyageId=active.id; vesselData.progress=0.00;
+      }
+
+      if(active){
+        const etd=new Date(active.etd), eta=new Date(active.eta);
+        const total=eta-etd;
+        if(currentSimDate>=etd && currentSimDate<=eta){
+          if(active.status!=="Delayed") active.status="In Transit";
+          vesselData.status = active.status==="Delayed" ? "In Transit (Delayed)" : "In Transit to AGI";
+          vesselData.progress=(currentSimDate-etd)/total;
+          const [lat,lon]=interpolateOnRoute(vesselData.progress);
+          vesselData.marker.setLatLng([lat,lon]);
+        }else if(currentSimDate>eta){
+          if(active.status!=="Completed"){
+            active.status="Completed";
+            vesselData.marker.setLatLng(vesselData.route[vesselData.route.length-1]);
+            vesselData.status="Discharging @ AGI";
+            setTimeout(()=>{
+              vesselData.marker.setLatLng(vesselData.route[0]);
+              vesselData.status="Ready for Loading @ MW4";
+              updateInfoPanel();
+            }, 4000);
+          }
+        }
+      }
+
+      updateInfoPanel();
+      renderSchedule();
+    }
+
+    const scheduleInput = document.getElementById('file-schedule');
+    const weatherInput  = document.getElementById('file-weather');
+    const scheduleLabel = document.getElementById('label-schedule');
+    const weatherLabel  = document.getElementById('label-weather');
+
+    scheduleLabel.addEventListener('click',()=> scheduleInput.click());
+    weatherLabel.addEventListener('click',()=> weatherInput.click());
+
+    scheduleInput.addEventListener('change', (e)=>{
+      if(e.target.files.length===0) return;
+      const f = e.target.files[0];
+      const reader = new FileReader();
+      reader.onload = () => {
+        try{
+          let rows;
+          if(f.name.toLowerCase().endsWith('.json')){
+            const data = JSON.parse(reader.result);
+            if(!Array.isArray(data)) throw new Error('JSON must be an array');
+            rows = data;
+          } else {
+            rows = parseCSV(reader.result);
+          }
+          const normalized = rows.map(r=>{
+            const id = r.id || r.Voyage || r.voyage || r.trip || '';
+            const cargo = r.cargo || r.Cargo || '';
+            const etd = r.etd || r.ETD || r.departure || '';
+            const eta = r.eta || r.ETA || r.arrival || '';
+            const status = r.status || r.Status || 'Scheduled';
+            const etdDt = parseISO(etd), etaDt = parseISO(eta);
+            if(!id || !cargo || !etdDt || !etaDt) throw new Error('Missing required fields (id,cargo,etd,eta)');
+            return { id:String(id).trim(), cargo:String(cargo).trim(), etd:fmtIso(etdDt), eta:fmtIso(etaDt), status:String(status).trim() };
+          });
+          voyageSchedule = normalized.sort((a,b)=> +new Date(a.etd)-+new Date(b.etd));
+          scheduleLabel.textContent = `Loaded: ${f.name}`;
+          setInfo(`스케줄 ${normalized.length}건 로드 완료.`, 'info');
+          renderSchedule();
+        }catch(err){
+          console.error(err);
+          setInfo(`⚠️ 스케줄 파일 오류: ${err.message}`, 'danger');
+        }
+      };
+      reader.readAsText(f);
+    });
+
+    weatherInput.addEventListener('change', (e)=>{
+      if(e.target.files.length===0) return;
+      const f = e.target.files[0];
+      const reader = new FileReader();
+      reader.onload = ()=>{
+        try{
+          const rows = parseCSV(reader.result);
+          buildWeatherWindows(rows);
+          weatherLabel.textContent = `Loaded: ${f.name}`;
+          weatherLinked = true;
+          applyWeatherToSchedule();
+        }catch(err){
+          console.error(err);
+          setInfo(`⚠️ 날씨 파일 오류: ${err.message}`, 'danger');
+        }
+      };
+      reader.readAsText(f);
+    });
+
+    const briefingModal=document.getElementById('briefing-modal');
+    const assistantModal=document.getElementById('assistant-modal');
+    const modalTitle=document.getElementById('modal-title');
+    const modalContent=document.getElementById('modal-content');
+
+    function openModal(el){ 
+      el.classList.remove('opacity-0','pointer-events-none'); 
+      el.setAttribute('aria-hidden', 'false');
+      document.body.classList.add('modal-open'); 
+      // Focus management
+      const focusableElements = el.querySelectorAll('button, input, select, textarea, [tabindex]:not([tabindex="-1"])');
+      if(focusableElements.length > 0) {
+        focusableElements[0].focus();
+      }
+    }
+    function closeModal(el){ 
+      el.classList.add('opacity-0','pointer-events-none'); 
+      el.setAttribute('aria-hidden', 'true');
+      document.body.classList.remove('modal-open'); 
+    }
+    [briefingModal,assistantModal].forEach(m=> m.addEventListener('click', e=>{ if(e.target===m) closeModal(m); }));
+    document.addEventListener('keydown', e=>{ if(e.key==='Escape'){ [briefingModal,assistantModal].forEach(closeModal); } });
+
+    function renderAttachmentList(){
+      if(pendingAttachments.length===0){
+        assistantAttachments.innerHTML = '<div class="text-slate-500">No attachments selected.</div>';
+        return;
+      }
+      assistantAttachments.innerHTML = pendingAttachments.map((file,idx)=>{
+        return `<div class="flex justify-between items-center bg-slate-900/80 px-2 py-1 rounded">
+                  <span class="truncate max-w-[14rem]">${file.name}</span>
+                  <button data-index="${idx}" class="text-rose-300 hover:text-rose-400 remove-attachment">Remove</button>
+                </div>`;
+      }).join('');
+      assistantAttachments.querySelectorAll('.remove-attachment').forEach(btn=>{
+        btn.addEventListener('click',(ev)=>{
+          const idx = Number(ev.target.getAttribute('data-index'));
+          pendingAttachments.splice(idx,1);
+          renderAttachmentList();
+        });
+      });
+    }
+
+    assistantAttachments.innerHTML = '<div class="text-slate-500">No attachments selected.</div>';
+
+    document.getElementById('assistant-attach-btn').addEventListener('click', ()=> assistantFileInput.click());
+    assistantFileInput.addEventListener('change', (event)=>{
+      pendingAttachments = Array.from(event.target.files || []);
+      renderAttachmentList();
+    });
+
+    document.getElementById('assistant-reset').addEventListener('click', ()=>{
+      assistantHistory = [];
+      assistantConversation.innerHTML = '<div class="text-slate-400">무엇을 도와드릴까요? (예: “다음 3일 스케줄 요약”)</div>';
+      assistantUsage.textContent='';
+    });
+
+    async function callAssistant(prompt, attachments){
+      const formData = new FormData();
+      formData.append('prompt', prompt);
+      formData.append('history', JSON.stringify(assistantHistory));
+      formData.append('model', assistantModelSelect.value);
+      attachments.forEach(file=> formData.append('files', file, file.name));
+      const res = await fetch(`${API_BASE}/api/assistant`, { method:'POST', body: formData });
+      if(!res.ok){
+        const text = await res.text();
+        throw new Error(text || 'Assistant call failed');
+      }
+      const data = await res.json();
+      assistantHistory.push({role:'user', content: prompt});
+      assistantHistory.push({role:'assistant', content: data.answer});
+      assistantUsage.textContent = `Last response model: ${assistantModelSelect.value}`;
+      return data.answer;
+    }
+
+    async function fetchBriefing(){
+      modalTitle.textContent = '✨ Daily Briefing';
+      modalContent.innerHTML = '생성 중...';
+      openModal(briefingModal);
+      const payload = {
+        current_time: currentSimDate.toISOString(),
+        vessel_name: vesselData.name,
+        vessel_status: vesselData.status,
+        current_voyage: vesselData.currentVoyageId,
+        schedule: voyageSchedule,
+        weather_windows: weatherWindows.map(w=>({
+          start: w.start ? w.start.toISOString?.() || w.start : w.start,
+          end: w.end ? w.end.toISOString?.() || w.end : w.end,
+          level: w.level,
+          waveM: w.waveM,
+          windKt: w.windKt,
+          visKm: w.visKm
+        }))
+      };
+      try{
+        const res = await fetch(`${API_BASE}/api/briefing`, {
+          method:'POST',
+          headers:{'Content-Type':'application/json'},
+          body: JSON.stringify(payload)
+        });
+        if(!res.ok) throw new Error(await res.text());
+        const data = await res.json();
+        modalContent.innerHTML = data.briefing.replace(/\n/g,'<br>');
+      }catch(err){
+        console.error(err);
+        const cur = voyageSchedule.find(v=>v.id===vesselData.currentVoyageId);
+        const fallback = `현재 시각 ${toLocal(currentSimDate)}.\n진행 항차: ${cur?.id || 'N/A'} / 화물: ${cur?.cargo || 'N/A'} / 상태: ${vesselData.status}.`;
+        modalContent.innerHTML = `${fallback.replace(/\n/g,'<br>')}<br><br><span class="text-rose-300">AI Briefing unavailable: ${err.message}</span>`;
+      }
+    }
+
+    async function runRiskScan(){
+      const prompt = `다음 일정과 기상창을 기반으로 3가지 위험 시나리오와 대응 권고를 bullet로 정리해줘.\n일정: ${JSON.stringify(voyageSchedule)}\n기상: ${JSON.stringify(weatherWindows)}`;
+      setInfo('AI 위험 스캔 실행 중...', 'info');
+      try{
+        const answer = await callAssistant(prompt, []);
+        setInfo(answer.replace(/\n/g,'<br>'), 'warn');
+      }catch(err){
+        setInfo(`AI 위험 스캔 실패: ${err.message}`, 'danger');
+      }
+    }
+
+    document.getElementById('briefing-btn').addEventListener('click', fetchBriefing);
+    document.getElementById('btn-ai-risk').addEventListener('click', runRiskScan);
+    document.getElementById('close-modal-btn').addEventListener('click', ()=>closeModal(briefingModal));
+    document.getElementById('assistant-btn').addEventListener('click', ()=>openModal(assistantModal));
+    document.getElementById('close-assistant-btn').addEventListener('click', ()=>closeModal(assistantModal));
+
+    document.getElementById('assistant-form').addEventListener('submit', async (e)=>{
+      e.preventDefault();
+      const input=document.getElementById('assistant-input');
+      const q=input.value.trim(); if(!q) return;
+      assistantConversation.innerHTML += `<div class="text-right"><span class="bg-purple-800/80 p-2 rounded-lg inline-block">${q}</span></div>`;
+      input.value='';
+      assistantConversation.scrollTop=assistantConversation.scrollHeight;
+      try{
+        const ans = await callAssistant(q, pendingAttachments);
+        assistantConversation.innerHTML += `<div class="text-left"><span class="bg-slate-800 p-2 rounded-lg inline-block">${ans.replace(/\n/g,'<br>')}</span></div>`;
+        assistantConversation.scrollTop=assistantConversation.scrollHeight;
+        pendingAttachments = [];
+        assistantFileInput.value = '';
+        renderAttachmentList();
+      }catch(err){
+        assistantConversation.innerHTML += `<div class="text-left text-rose-300">${err.message}</div>`;
+        assistantConversation.scrollTop=assistantConversation.scrollHeight;
+      }
+    });
+
+    document.getElementById('btn-reset').addEventListener('click', ()=>{
+      currentSimDate = new Date("2025-09-28T12:00:00Z");
+      vesselData.currentVoyageId = null;
+      vesselData.status = "Ready @ MW4";
+      setInfo('시뮬레이션 시계가 초기화되었습니다.');
+    });
+
+    // Marine data functions
+    async function updateMarineForLeg(portName) {
+      // 워커로 오프로드
+      const snap = await fetchMarineAndIOIInWorker(portName);
+      if (snap && snap.hs != null && snap.windKt != null) {
+        marineBadge.textContent = `Hs: ${snap.hs.toFixed(2)} m · Wind: ${Math.round(snap.windKt)} kt`;
+      } else {
+        marineBadge.textContent = `Marine: n/a`;
+      }
+      return snap;
+    }
+
+    // ===== Worker 생성 (Blob URL) : IOI 계산 + Marine fetch 오프로드 =====
+    const workerCode = `
+      self.addEventListener('message', async (e) => {
+        const { type, payload } = e.data || {};
+        if (type === 'marine+ioi') {
+          const { port, coords, RULE } = payload;
+          try {
+            const params = new URLSearchParams({
+              latitude: String(coords.lat),
+              longitude: String(coords.lon),
+              hourly: ['wave_height','wind_speed_10m','swell_wave_period'].join(','),
+              timezone: 'auto'
+            });
+            const url = 'https://marine-api.open-meteo.com/v1/marine?' + params.toString();
+            const r = await fetch(url);
+            const j = await r.json();
+            const idx = 0;
+            const hs = j?.hourly?.wave_height?.[idx] ?? null;
+            const wsms = j?.hourly?.wind_speed_10m?.[idx] ?? null;
+            const sp = j?.hourly?.swell_wave_period?.[idx] ?? null;
+            const windKt = wsms != null ? (wsms * 1.94384) : null;
+            // IOI 계산 (워커쪽 동일 로직)
+            function ioiCalc(hs, windKt, sp, RULE){
+              const hsScore = (hs==null)?0.5:(hs<=RULE.hs_caution?1:hs>=RULE.hs_nogo?0:1-((hs-RULE.hs_caution)/(RULE.hs_nogo-RULE.hs_caution)));
+              const wScore  = (windKt==null)?0.5:(windKt<=RULE.wind_caution?1:windKt>=RULE.wind_nogo?0:1-((windKt-RULE.wind_caution)/(RULE.wind_nogo-RULE.wind_caution)));
+              const spMin=6, spMax=12; const s = Math.max(spMin, Math.min(spMax, (sp ?? 8)));
+              const swellScore = (s-spMin)/(spMax-spMin);
+              const score = 0.5*hsScore + 0.35*wScore + 0.15*swellScore;
+              return Math.round(score*100);
+            }
+            const ioi = ioiCalc(hs, windKt, sp, RULE);
+            self.postMessage({ type:'marine+ioi:done', payload:{ port, hs, windKt, sp, ioi }});
+          } catch (err) {
+            self.postMessage({ type:'marine+ioi:error', payload:{ port, error: String(err) }});
+          }
+        }
+      });
+    `;
+    const workerUrl = URL.createObjectURL(new Blob([workerCode], {type:'text/javascript'}));
+    const marineWorker = new Worker(workerUrl, { type:'module' });
+    const pendingIOI = new Map(); // port -> Promise resolvers
+    marineWorker.addEventListener('message', (e)=>{
+      const { type, payload } = e.data || {};
+      if (type === 'marine+ioi:done') {
+        const { port, hs, windKt, sp, ioi } = payload;
+        const resolver = pendingIOI.get(port);
+        if (resolver) { resolver.resolve({ hs, windKt, swellPeriod: sp, ioi }); pendingIOI.delete(port); }
+      } else if (type === 'marine+ioi:error') {
+        const resolver = pendingIOI.get(payload.port);
+        if (resolver) { resolver.resolve(null); pendingIOI.delete(payload.port); }
+      }
+    });
+    function fetchMarineAndIOIInWorker(portName) {
+      const coords = portCoords[portName];
+      if (!coords) return Promise.resolve(null);
+      return new Promise((resolve)=> {
+        pendingIOI.set(portName, { resolve });
+        marineWorker.postMessage({ type:'marine+ioi', payload: { port: portName, coords, RULE }});
+      });
+    }
+
+    // Passive listeners (스크롤/터치)
+    window.addEventListener('scroll', ()=>{}, { passive:true });
+    window.addEventListener('touchstart', ()=>{}, { passive:true });
+
+    setInterval(runSimulation, 50);
+    runSimulation();
+  });
+  </script>
+</body>
+</html>

--- a/openai_gateway.py
+++ b/openai_gateway.py
@@ -16,7 +16,6 @@ from openai import AsyncOpenAI
 from pydantic import BaseModel, ConfigDict, Field
 from PyPDF2 import PdfReader
 
-
 LOGGER = logging.getLogger(__name__)
 
 
@@ -257,9 +256,7 @@ async def run_assistant(
         TypeError,
         ValueError,
     ) as exc:  # pragma: no cover - validation
-        raise HTTPException(
-            status_code=400, detail=f"Invalid history payload: {exc}"
-        ) from exc
+        raise HTTPException(status_code=400, detail=f"Invalid history payload: {exc}") from exc
 
     attachments = list(files or [])
     payloads: List[bytes] = []

--- a/openai_gateway.py
+++ b/openai_gateway.py
@@ -42,6 +42,7 @@ class BriefingRequest(LogiBaseModel):
     current_voyage: str | None = None
     schedule: List[dict] = Field(default_factory=list)
     weather_windows: List[dict] = Field(default_factory=list)
+    model: str = Field(default="gpt-4.1-mini", max_length=64)
 
 
 class BriefingResponse(LogiBaseModel):

--- a/openai_gateway.py
+++ b/openai_gateway.py
@@ -1,0 +1,235 @@
+"""OpenAI 연동 FastAPI 백엔드. | FastAPI backend wired with OpenAI."""
+
+from __future__ import annotations
+
+import base64
+import io
+import json
+import logging
+import os
+from typing import Iterable, List, Literal, Sequence
+
+from fastapi import FastAPI, File, Form, HTTPException, UploadFile
+from fastapi.middleware.cors import CORSMiddleware
+from openai import AsyncOpenAI
+from openai.types.chat import ChatCompletion
+from pydantic import BaseModel, ConfigDict, Field
+from PyPDF2 import PdfReader
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class LogiBaseModel(BaseModel):
+    """로지스틱 도메인 공통 베이스 모델. | Common logistics base model."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+
+class ChatMessage(LogiBaseModel):
+    """사용자/AI 메시지 구조. | Chat message schema."""
+
+    role: Literal["user", "assistant", "system"]
+    content: str = Field(..., max_length=6000)
+
+
+class BriefingRequest(LogiBaseModel):
+    """일일 브리핑 요청 본문. | Daily briefing payload."""
+
+    current_time: str
+    vessel_name: str
+    vessel_status: str
+    current_voyage: str | None = None
+    schedule: List[dict] = Field(default_factory=list)
+    weather_windows: List[dict] = Field(default_factory=list)
+
+
+class BriefingResponse(LogiBaseModel):
+    """일일 브리핑 응답. | Daily briefing response."""
+
+    briefing: str
+
+
+class AssistantResponse(LogiBaseModel):
+    """AI 어시스턴트 응답. | AI assistant response."""
+
+    answer: str
+
+
+_async_client: AsyncOpenAI | None = None
+
+
+def _require_client() -> AsyncOpenAI:
+    """OpenAI 클라이언트를 생성. | Build an OpenAI client."""
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise HTTPException(status_code=500, detail="OPENAI_API_KEY is not configured")
+    global _async_client
+    if _async_client is None:
+        _async_client = AsyncOpenAI(api_key=api_key)
+    return _async_client
+
+
+def _pdf_to_text(payload: bytes) -> str:
+    """PDF를 텍스트로 추출. | Extract text from PDF."""
+
+    reader = PdfReader(io.BytesIO(payload))
+    text_chunks: List[str] = []
+    for page in reader.pages:
+        snippet = page.extract_text() or ""
+        text_chunks.append(snippet)
+    return "\n".join(text_chunks)
+
+
+def _image_to_base64(file: UploadFile, payload: bytes) -> dict:
+    """이미지를 base64로 인코딩. | Encode image to base64."""
+
+    data_url = f"data:{file.content_type};base64,{base64.b64encode(payload).decode('utf-8')}"
+    return {"type": "input_image", "image_url": data_url}
+
+
+def _build_user_content(prompt: str, files: Iterable[UploadFile], raw_payloads: List[bytes]) -> str:
+    """사용자 메시지 콘텐츠 구성. | Compose user content payload."""
+
+    content_parts = [prompt]
+    for idx, file in enumerate(files):
+        data = raw_payloads[idx]
+        if file.content_type and file.content_type.startswith("image/"):
+            # For images, we'll include a reference in the text
+            content_parts.append(f"\n[첨부 이미지: {file.filename}]")
+        elif (file.content_type == "application/pdf") or file.filename.lower().endswith(".pdf"):
+            pdf_text = _pdf_to_text(data)[:8000]
+            descriptor = f"\n[첨부 PDF: {file.filename}]\n"
+            content_parts.append(descriptor + pdf_text)
+        else:
+            try:
+                decoded = data.decode("utf-8")
+            except UnicodeDecodeError:
+                decoded = base64.b64encode(data).decode("utf-8")
+                decoded = f"[base64-encoded attachment]\n{decoded[:6000]}"
+            content_parts.append(f"\n[첨부 파일: {file.filename}]\n{decoded[:8000]}")
+    return "\n".join(content_parts)
+
+
+def _extract_output_text(response: ChatCompletion) -> str:
+    """Chat Completion 결과에서 텍스트 추출. | Extract text from Chat Completion."""
+
+    try:
+        return response.choices[0].message.content
+    except (AttributeError, IndexError, KeyError):
+        return "Error: Could not extract response text"
+
+
+async def _call_openai(messages: List[dict], *, model: str) -> ChatCompletion:
+    """OpenAI Responses API 호출. | Invoke OpenAI Responses API."""
+
+    client = _require_client()
+    return await client.chat.completions.create(model=model, messages=messages)
+
+
+def _build_history(messages: Sequence[ChatMessage]) -> List[dict]:
+    """Chat Completion용 메시지 배열 구성. | Build chat completion messages."""
+
+    history: List[dict] = []
+    for item in messages:
+        history.append({
+            "role": item.role,
+            "content": item.content
+        })
+    return history
+
+
+app = FastAPI(title="HVDC Logistics AI Gateway", version="1.0.0")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.get("/health")
+async def healthcheck() -> dict:
+    """헬스체크. | Service health check."""
+
+    return {"status": "ok"}
+
+
+@app.post("/api/assistant", response_model=AssistantResponse)
+async def run_assistant(
+    prompt: str = Form(..., max_length=4000),
+    history: str = Form("[]"),
+    files: List[UploadFile] | None = File(default=None),
+    model: str = Form("gpt-4.1-mini"),
+) -> AssistantResponse:
+    """어시스턴트 호출. | Execute assistant call."""
+
+    try:
+        raw_history = json.loads(history)
+        history_messages = [ChatMessage.model_validate(item) for item in raw_history]
+    except (json.JSONDecodeError, TypeError, ValueError) as exc:  # pragma: no cover - validation
+        raise HTTPException(status_code=400, detail=f"Invalid history payload: {exc}") from exc
+
+    attachments = list(files or [])
+    payloads: List[bytes] = []
+    for file in attachments:
+        payloads.append(await file.read())
+
+    messages = _build_history(history_messages)
+    messages.append({"role": "user", "content": _build_user_content(prompt, attachments, payloads)})
+
+    try:
+        response = await _call_openai(messages, model=model)
+    except Exception as exc:  # pragma: no cover - network failure
+        LOGGER.exception("OpenAI call failed")
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+    return AssistantResponse(answer=_extract_output_text(response))
+
+
+@app.post("/api/briefing", response_model=BriefingResponse)
+async def generate_briefing(payload: BriefingRequest) -> BriefingResponse:
+    """일일 브리핑 생성. | Create a daily briefing."""
+
+    schedule_summary = json.dumps(payload.schedule, ensure_ascii=False, indent=2)
+    weather_summary = json.dumps(payload.weather_windows, ensure_ascii=False, indent=2)
+    prompt = (
+        "당신은 해상 물류 관제 전문가입니다. 아래 데이터를 참고하여 200자 내외의 한국어 일일 브리핑을 작성하세요."
+        "\n- 현재 시각: {time}\n- 선박명: {vessel}\n- 현재 항차: {voyage}\n- 선박 상태: {status}\n"
+        "- 전체 일정: {schedule}\n- 기상 윈도우: {weather}\n"
+        "브리핑은 핵심 일정, 위험, 권고사항을 bullet로 정리하세요."
+    ).format(
+        time=payload.current_time,
+        vessel=payload.vessel_name,
+        voyage=payload.current_voyage or "N/A",
+        status=payload.vessel_status,
+        schedule=schedule_summary,
+        weather=weather_summary,
+    )
+
+    try:
+        response = await _call_openai(
+            [
+                {
+                    "role": "system",
+                    "content": "당신은 HVDC 프로젝트 물류 전문가입니다. 일일 브리핑을 한국어로 작성하세요.",
+                },
+                {
+                    "role": "user",
+                    "content": prompt,
+                },
+            ],
+            model=payload.model,
+        )
+    except Exception as exc:  # pragma: no cover - network failure
+        LOGGER.exception("OpenAI call failed")
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+    return BriefingResponse(briefing=_extract_output_text(response))
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/openai_gateway.py
+++ b/openai_gateway.py
@@ -7,12 +7,12 @@ import io
 import json
 import logging
 import os
-from typing import Iterable, List, Literal, Sequence
+from pathlib import Path
+from typing import Any, Iterable, List, Literal, Sequence
 
 from fastapi import FastAPI, File, Form, HTTPException, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from openai import AsyncOpenAI
-from openai.types.chat import ChatCompletion
 from pydantic import BaseModel, ConfigDict, Field
 from PyPDF2 import PdfReader
 
@@ -57,14 +57,47 @@ class AssistantResponse(LogiBaseModel):
 
 
 _async_client: AsyncOpenAI | None = None
+_dotenv_loaded = False
+
+
+def _load_dotenv() -> None:
+    """로컬 .env 파일에서 환경변수를 로드. | Load environment variables from .env."""
+
+    global _dotenv_loaded
+    if _dotenv_loaded:
+        return
+
+    candidates = [
+        Path.cwd() / ".env",
+        Path(__file__).resolve().parent / ".env",
+    ]
+    for env_path in candidates:
+        if not env_path.exists():
+            continue
+        try:
+            with env_path.open("r", encoding="utf-8") as handle:
+                for raw_line in handle:
+                    line = raw_line.strip()
+                    if not line or line.startswith("#") or "=" not in line:
+                        continue
+                    key, value = line.split("=", maxsplit=1)
+                    key = key.strip()
+                    value = value.strip().strip('"').strip("'")
+                    if key and key not in os.environ:
+                        os.environ[key] = value
+        except OSError as exc:  # pragma: no cover - filesystem edge
+            LOGGER.warning("Failed to load .env file %s: %s", env_path, exc)
+    _dotenv_loaded = True
 
 
 def _require_client() -> AsyncOpenAI:
     """OpenAI 클라이언트를 생성. | Build an OpenAI client."""
 
+    _load_dotenv()
     api_key = os.getenv("OPENAI_API_KEY")
     if not api_key:
-        raise HTTPException(status_code=500, detail="OPENAI_API_KEY is not configured")
+        error_message = "OPENAI_API_KEY is not configured"
+        raise HTTPException(status_code=500, detail=error_message)
     global _async_client
     if _async_client is None:
         _async_client = AsyncOpenAI(api_key=api_key)
@@ -85,35 +118,78 @@ def _pdf_to_text(payload: bytes) -> str:
 def _image_to_base64(file: UploadFile, payload: bytes) -> dict:
     """이미지를 base64로 인코딩. | Encode image to base64."""
 
-    data_url = f"data:{file.content_type};base64,{base64.b64encode(payload).decode('utf-8')}"
-    return {"type": "input_image", "image_url": data_url}
+    data_url = "data:{media};base64,{payload}".format(
+        media=file.content_type,
+        payload=base64.b64encode(payload).decode("utf-8"),
+    )
+    return {"type": "input_image", "image_url": {"url": data_url}}
 
 
-def _build_user_content(prompt: str, files: Iterable[UploadFile], raw_payloads: List[bytes]) -> str:
+def _build_user_content(
+    prompt: str, files: Iterable[UploadFile], raw_payloads: List[bytes]
+) -> List[dict[str, Any]]:
     """사용자 메시지 콘텐츠 구성. | Compose user content payload."""
 
-    content_parts = [prompt]
+    content: List[dict[str, Any]] = [{"type": "text", "text": prompt}]
     for idx, file in enumerate(files):
         data = raw_payloads[idx]
+        filename = file.filename or f"attachment-{idx+1}"
         if file.content_type and file.content_type.startswith("image/"):
-            # For images, we'll include a reference in the text
-            content_parts.append(f"\n[첨부 이미지: {file.filename}]")
-        elif (file.content_type == "application/pdf") or file.filename.lower().endswith(".pdf"):
+            content.append(
+                {
+                    "type": "text",
+                    "text": f"[이미지 첨부: {filename}]",
+                }
+            )
+            content.append(_image_to_base64(file, data))
+            continue
+
+        is_pdf_content = file.content_type == "application/pdf"
+        if is_pdf_content or filename.lower().endswith(".pdf"):
             pdf_text = _pdf_to_text(data)[:8000]
-            descriptor = f"\n[첨부 PDF: {file.filename}]\n"
-            content_parts.append(descriptor + pdf_text)
-        else:
-            try:
-                decoded = data.decode("utf-8")
-            except UnicodeDecodeError:
-                decoded = base64.b64encode(data).decode("utf-8")
-                decoded = f"[base64-encoded attachment]\n{decoded[:6000]}"
-            content_parts.append(f"\n[첨부 파일: {file.filename}]\n{decoded[:8000]}")
-    return "\n".join(content_parts)
+            descriptor = f"[PDF 첨부: {filename}]\n{pdf_text}"
+            content.append(
+                {
+                    "type": "text",
+                    "text": descriptor,
+                }
+            )
+            continue
+
+        try:
+            decoded = data.decode("utf-8")
+        except UnicodeDecodeError:
+            decoded = base64.b64encode(data).decode("utf-8")
+            decoded = f"[base64-encoded attachment]\n{decoded[:6000]}"
+        content.append(
+            {
+                "type": "text",
+                "text": f"[파일 첨부: {filename}]\n{decoded[:8000]}",
+            }
+        )
+
+    return content
 
 
-def _extract_output_text(response: ChatCompletion) -> str:
+def _extract_output_text(response: Any) -> str:
     """Chat Completion 결과에서 텍스트 추출. | Extract text from Chat Completion."""
+
+    outputs = getattr(response, "output", None)
+    if outputs:
+        texts: List[str] = []
+        for item in outputs:
+            if getattr(item, "type", None) != "message":
+                continue
+            message = getattr(item, "message", None)
+            if not message:
+                continue
+            for block in getattr(message, "content", []) or []:
+                if getattr(block, "type", None) == "text":
+                    text_value = getattr(block, "text", "")
+                    if text_value:
+                        texts.append(text_value)
+        if texts:
+            return "\n".join(texts)
 
     try:
         return response.choices[0].message.content
@@ -121,22 +197,26 @@ def _extract_output_text(response: ChatCompletion) -> str:
         return "Error: Could not extract response text"
 
 
-async def _call_openai(messages: List[dict], *, model: str) -> ChatCompletion:
+async def _call_openai(messages: List[dict[str, Any]], *, model: str) -> Any:
     """OpenAI Responses API 호출. | Invoke OpenAI Responses API."""
 
     client = _require_client()
-    return await client.chat.completions.create(model=model, messages=messages)
+    return await client.responses.create(model=model, input=messages)
 
 
-def _build_history(messages: Sequence[ChatMessage]) -> List[dict]:
+def _build_history(messages: Sequence[ChatMessage]) -> List[dict[str, Any]]:
     """Chat Completion용 메시지 배열 구성. | Build chat completion messages."""
 
-    history: List[dict] = []
+    history: List[dict[str, Any]] = []
     for item in messages:
-        history.append({
-            "role": item.role,
-            "content": item.content
-        })
+        history.append(
+            {
+                "role": item.role,
+                "content": [
+                    {"type": "text", "text": item.content},
+                ],
+            }
+        )
     return history
 
 
@@ -168,9 +248,17 @@ async def run_assistant(
 
     try:
         raw_history = json.loads(history)
-        history_messages = [ChatMessage.model_validate(item) for item in raw_history]
-    except (json.JSONDecodeError, TypeError, ValueError) as exc:  # pragma: no cover - validation
-        raise HTTPException(status_code=400, detail=f"Invalid history payload: {exc}") from exc
+        history_messages: List[ChatMessage] = []
+        for item in raw_history:
+            history_messages.append(ChatMessage.model_validate(item))
+    except (
+        json.JSONDecodeError,
+        TypeError,
+        ValueError,
+    ) as exc:  # pragma: no cover - validation
+        raise HTTPException(
+            status_code=400, detail=f"Invalid history payload: {exc}"
+        ) from exc
 
     attachments = list(files or [])
     payloads: List[bytes] = []
@@ -178,10 +266,17 @@ async def run_assistant(
         payloads.append(await file.read())
 
     messages = _build_history(history_messages)
-    messages.append({"role": "user", "content": _build_user_content(prompt, attachments, payloads)})
+    messages.append(
+        {
+            "role": "user",
+            "content": _build_user_content(prompt, attachments, payloads),
+        }
+    )
 
     try:
         response = await _call_openai(messages, model=model)
+    except HTTPException:
+        raise
     except Exception as exc:  # pragma: no cover - network failure
         LOGGER.exception("OpenAI call failed")
         raise HTTPException(status_code=502, detail=str(exc)) from exc
@@ -193,14 +288,28 @@ async def run_assistant(
 async def generate_briefing(payload: BriefingRequest) -> BriefingResponse:
     """일일 브리핑 생성. | Create a daily briefing."""
 
-    schedule_summary = json.dumps(payload.schedule, ensure_ascii=False, indent=2)
-    weather_summary = json.dumps(payload.weather_windows, ensure_ascii=False, indent=2)
-    prompt = (
-        "당신은 해상 물류 관제 전문가입니다. 아래 데이터를 참고하여 200자 내외의 한국어 일일 브리핑을 작성하세요."
-        "\n- 현재 시각: {time}\n- 선박명: {vessel}\n- 현재 항차: {voyage}\n- 선박 상태: {status}\n"
-        "- 전체 일정: {schedule}\n- 기상 윈도우: {weather}\n"
-        "브리핑은 핵심 일정, 위험, 권고사항을 bullet로 정리하세요."
-    ).format(
+    schedule_summary = json.dumps(
+        payload.schedule,
+        ensure_ascii=False,
+        indent=2,
+    )
+    weather_summary = json.dumps(
+        payload.weather_windows,
+        ensure_ascii=False,
+        indent=2,
+    )
+    prompt_template = (
+        "당신은 해상 물류 관제 전문가입니다. "
+        "아래 데이터를 참고하여 200자 내외의 한국어 일일 브리핑을 작성하세요."
+        "\n- 현재 시각: {time}"
+        "\n- 선박명: {vessel}"
+        "\n- 현재 항차: {voyage}"
+        "\n- 선박 상태: {status}"
+        "\n- 전체 일정: {schedule}"
+        "\n- 기상 윈도우: {weather}"
+        "\n브리핑은 핵심 일정, 위험, 권고사항을 bullet로 정리하세요."
+    )
+    prompt = prompt_template.format(
         time=payload.current_time,
         vessel=payload.vessel_name,
         voyage=payload.current_voyage or "N/A",
@@ -214,15 +323,30 @@ async def generate_briefing(payload: BriefingRequest) -> BriefingResponse:
             [
                 {
                     "role": "system",
-                    "content": "당신은 HVDC 프로젝트 물류 전문가입니다. 일일 브리핑을 한국어로 작성하세요.",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": (
+                                "당신은 HVDC 프로젝트 물류 전문가입니다. "
+                                "일일 브리핑을 한국어로 작성하세요."
+                            ),
+                        }
+                    ],
                 },
                 {
                     "role": "user",
-                    "content": prompt,
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": prompt,
+                        }
+                    ],
                 },
             ],
             model=payload.model,
         )
+    except HTTPException:
+        raise
     except Exception as exc:  # pragma: no cover - network failure
         LOGGER.exception("OpenAI call failed")
         raise HTTPException(status_code=502, detail=str(exc)) from exc
@@ -232,4 +356,5 @@ async def generate_briefing(payload: BriefingRequest) -> BriefingResponse:
 
 if __name__ == "__main__":
     import uvicorn
+
     uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,26 @@
+# TDD Plan (RED → GREEN → REFACTOR)
+
+## Loop 1: Core Domain & Risk Rules
+- **Red**: Write tests for `ForecastPoint` validation, caching utilities, and `compute_risk_level` boundaries (Hs, wind, missing swell).
+- **Green**: Implement `LogiBaseModel`, domain models, risk computation with env overrides, numeric formatting helper.
+- **Refactor**: Extract configuration module and ensure structured logging setup.
+
+## Loop 2: Provider Adapters & Cache Fallback
+- **Red**: Add adapter tests covering success, HTTP 429 retry/fallback, timeout with cache usage.
+- **Green**: Implement Stormglass, Open-Meteo Marine, NOAA WW3 adapters with retry/backoff, disk cache, environment-driven config.
+- **Refactor**: Generalize provider registry and response normalization utilities.
+
+## Loop 3: Scheduler & Weekly Suggestions
+- **Red**: Create tests for `generate_weekly_schedule` output, CSV/ICS creation, timezone correctness.
+- **Green**: Implement scheduler module generating STDOUT table, CSV, ICS; integrate with risk notes.
+- **Refactor**: Optimize schedule formatting and share table rendering utilities.
+
+## Loop 4: Notifications & CLI Commands
+- **Red**: Write tests for notification dispatch (email/slack/telegram dry-run) and CLI commands (`check --now`, `schedule --week`, `notify --dry-run`).
+- **Green**: Implement notification channel classes, CLI using Typer, configuration loading, fallback sequencing.
+- **Refactor**: Improve logging context, ensure CLI shares service layer, polish message templates.
+
+## Loop 5: Integration & Cron Scheduler
+- **Red**: Add integration test verifying twice-daily trigger scheduling logic referencing Asia/Dubai timezone and fallback provider order.
+- **Green**: Implement scheduler service for auto checks, ensure timezone aware scheduling, update README/CHANGELOG/.env.example.
+- **Refactor**: Final tidy pass, ensure metrics hooks and configuration defaults extracted.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,54 @@
+[project]
+name = "weather-vessel"
+version = "0.1.0"
+description = "Marine weather routing and notification toolkit"
+readme = "README.md"
+authors = [{ name = "Weather Vessel Team" }]
+requires-python = ">=3.11"
+dependencies = [
+  "httpx>=0.27",
+  "pydantic>=2.6",
+  "python-dotenv>=1.0",
+  "typer[all]>=0.9",
+]
+
+[project.optional-dependencies]
+all = [
+  "black>=24.0",
+  "flake8>=7.0",
+  "isort>=5.13",
+  "mypy>=1.8",
+  "pytest>=7.4",
+  "pytest-cov>=4.1",
+]
+
+[project.scripts]
+wv = "wv.cli:main"
+
+[tool.black]
+line-length = 100
+target-version = ["py311"]
+
+[tool.isort]
+profile = "black"
+line_length = 100
+
+[tool.flake8]
+max-line-length = 100
+extend-ignore = ["E203", "W503"]
+
+[tool.mypy]
+python_version = "3.11"
+strict = true
+mypy_path = "src"
+
+[tool.pytest.ini_options]
+addopts = "-q --cov=src"
+testpaths = ["tests"]
+
+[tool.coverage.report]
+fail_under = 70.0
+
+[build-system]
+requires = ["setuptools>=67", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,1 @@
-fastapi>=0.104.0
-uvicorn[standard]>=0.24.0
-openai>=1.0.0
-pydantic>=2.0.0
-PyPDF2>=3.0.0
-python-multipart>=0.0.6
+-e .[all]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi>=0.104.0
+uvicorn[standard]>=0.24.0
+openai>=1.0.0
+pydantic>=2.0.0
+PyPDF2>=3.0.0
+python-multipart>=0.0.6

--- a/src/wv/__init__.py
+++ b/src/wv/__init__.py
@@ -1,0 +1,5 @@
+"""해상 물류 기상 제어 시스템 패키지. | Maritime weather logistics control system package."""
+
+from .version import __version__
+
+__all__ = ["__version__"]

--- a/src/wv/cli.py
+++ b/src/wv/cli.py
@@ -1,0 +1,183 @@
+"""WV CLI 엔트리포인트. | WV CLI entrypoint."""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+import typer
+from dotenv import load_dotenv
+
+from wv.core.cache import CacheRepository
+from wv.core.risk import compute_risk
+from wv.core.utils import format_metric
+from wv.notify.email import EmailNotifier
+from wv.notify.manager import NotificationChannel, NotificationManager
+from wv.notify.slack import SlackNotifier
+from wv.notify.telegram import TelegramNotifier
+from wv.providers.noaa_ww3 import NoaaWaveWatchProvider
+from wv.providers.open_meteo import OpenMeteoMarineProvider
+from wv.providers.stormglass import StormglassProvider
+from wv.services.marine import MarineForecastService
+from wv.services.scheduler import VoyageScheduler
+
+app = typer.Typer(help="Marine weather and voyage planning CLI")
+LOGGER = logging.getLogger("wv.cli")
+
+ROUTE_COORDS: dict[str, Tuple[float, float]] = {
+    "MW4-AGI": (24.3488, 54.4651),
+    "AGI-1": (24.40, 54.70),
+    "AGI-2": (24.45, 54.65),
+}
+
+
+@dataclass
+class ServiceContainer:
+    """애플리케이션 서비스 묶음. | Application service bundle."""
+
+    _marine_service: MarineForecastService
+    _scheduler: VoyageScheduler
+    _notifier: NotificationManager
+
+    def marine_service(self) -> MarineForecastService:
+        return self._marine_service
+
+    def scheduler(self) -> VoyageScheduler:
+        return self._scheduler
+
+    def notifier(self) -> NotificationManager:
+        return self._notifier
+
+
+def build_service_container() -> ServiceContainer:
+    """서비스 컨테이너를 구성. | Build service container."""
+    load_dotenv()
+    cache = CacheRepository()
+    providers = [
+        StormglassProvider(),
+        OpenMeteoMarineProvider(),
+        NoaaWaveWatchProvider(),
+    ]
+    marine_service = MarineForecastService(providers=providers, cache=cache)
+    output_dir = Path(os.getenv("WV_OUTPUT_DIR", "outputs"))
+    scheduler = VoyageScheduler(marine_service=marine_service, output_dir=output_dir)
+    channels: List[NotificationChannel] = []
+    email_channel = EmailNotifier()
+    channels.append(email_channel)
+    slack_webhook = os.getenv("WV_SLACK_WEBHOOK")
+    if slack_webhook:
+        channels.append(SlackNotifier(webhook_url=slack_webhook))
+    telegram_token = os.getenv("WV_TELEGRAM_BOT_TOKEN")
+    telegram_chat = os.getenv("WV_TELEGRAM_CHAT_ID")
+    if telegram_token and telegram_chat:
+        channels.append(TelegramNotifier(bot_token=telegram_token, chat_id=telegram_chat))
+    notifier = NotificationManager(channels=channels)
+    return ServiceContainer(
+        _marine_service=marine_service,
+        _scheduler=scheduler,
+        _notifier=notifier,
+    )
+
+
+@app.command()
+def check(
+    now: bool = typer.Option(False, help="Run immediate risk assessment"),
+    lat: float = typer.Option(24.3488, help="Latitude"),
+    lon: float = typer.Option(54.4651, help="Longitude"),
+    hours: int = typer.Option(6, help="Forecast window in hours"),
+) -> None:
+    """현재 위험을 확인. | Check current risk."""
+    if not now:
+        typer.echo("Use --now to trigger immediate risk assessment.")
+        raise typer.Exit(code=1)
+    container = build_service_container()
+    service = container.marine_service()
+    points = service.get_forecast(lat=lat, lon=lon, hours=hours)
+    if not points:
+        typer.echo("No forecast data available.")
+        raise typer.Exit(code=2)
+    point = points[0]
+    assessment = compute_risk(point)
+    typer.echo(
+        "Risk: "
+        f"{assessment.level.value} | Hs {format_metric(point.hs, 'm')} | "
+        f"Wind {format_metric(point.wind_speed, 'kt')} | Reasons: {', '.join(assessment.reasons)}"
+    )
+
+
+@app.command()
+def schedule(
+    week: bool = typer.Option(False, help="Generate weekly schedule"),
+    lat: float = typer.Option(24.3488, help="Latitude"),
+    lon: float = typer.Option(54.4651, help="Longitude"),
+    vessel_speed: Optional[float] = typer.Option(None, help="Vessel speed in knots"),
+    route_distance_nm: Optional[float] = typer.Option(None, help="Route distance in NM"),
+    cargo_hs_limit: Optional[float] = typer.Option(None, help="Cargo handling Hs limit"),
+) -> None:
+    """주간 일정 생성. | Generate weekly schedule."""
+    if not week:
+        typer.echo("Use --week to produce weekly schedule.")
+        raise typer.Exit(code=1)
+    container = build_service_container()
+    scheduler_service = container.scheduler()
+    table = scheduler_service.generate_weekly_schedule(
+        lat=lat,
+        lon=lon,
+        vessel_speed=vessel_speed,
+        route_distance_nm=route_distance_nm,
+        cargo_hs_limit=cargo_hs_limit,
+    )
+    typer.echo(table)
+
+
+@app.command()
+def notify(
+    route: str = typer.Option(..., help="Route identifier"),
+    dry_run: bool = typer.Option(False, help="Do not send notifications"),
+    lat: Optional[float] = typer.Option(None, help="Override latitude"),
+    lon: Optional[float] = typer.Option(None, help="Override longitude"),
+) -> None:
+    """알림을 발송. | Send notifications."""
+    container = build_service_container()
+    service = container.marine_service()
+    notifier = container.notifier()
+    coord = ROUTE_COORDS.get(route)
+    if coord is None:
+        if lat is None or lon is None:
+            typer.echo(f"Unknown route {route} and coordinates not provided.")
+            raise typer.Exit(code=1)
+        target_lat, target_lon = lat, lon
+    else:
+        target_lat = lat if lat is not None else coord[0]
+        target_lon = lon if lon is not None else coord[1]
+    points = service.get_forecast(lat=target_lat, lon=target_lon, hours=48)
+    if not points:
+        typer.echo("No forecast data available.")
+        raise typer.Exit(code=2)
+    point = points[0]
+    assessment = compute_risk(point)
+    subject = f"Marine risk update - {route}"
+    body = (
+        f"Risk Level: {assessment.level.value}\n"
+        f"Hs: {format_metric(point.hs, 'm')}\n"
+        f"Wind: {format_metric(point.wind_speed, 'kt')}\n"
+        f"Reasons: {', '.join(assessment.reasons)}"
+    )
+    notifier.send_all(subject, body, dry_run=dry_run)
+    if dry_run:
+        typer.echo("Dry run: notification composed but not sent.")
+    else:
+        typer.echo("Notifications dispatched.")
+
+
+def main() -> None:
+    """CLI 진입점을 실행. | Run CLI entrypoint."""
+
+    app()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/wv/core/cache.py
+++ b/src/wv/core/cache.py
@@ -1,0 +1,59 @@
+"""디스크 캐시를 관리. | Manage disk cache."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Union
+
+CacheData = Union[Dict[str, Any], List[Any]]
+
+
+class CacheRepository:
+    """해상 데이터 캐시 저장소. | Marine data cache repository."""
+
+    def __init__(self, base_path: Path | None = None, ttl: timedelta | None = None) -> None:
+        self.base_path = base_path or Path.home() / ".wv" / "cache"
+        self.base_path.mkdir(parents=True, exist_ok=True)
+        self.ttl = ttl or timedelta(hours=3)
+
+    def make_key(self, provider: str, params: Dict[str, Any]) -> str:
+        """요청 키를 해시 생성. | Hash request parameters into key."""
+        fingerprint = json.dumps(
+            {"provider": provider, "params": params}, sort_keys=True, default=str
+        )
+        digest = hashlib.sha256(fingerprint.encode("utf-8")).hexdigest()
+        return f"{provider}_{digest}"
+
+    def _resolve_path(self, key: str) -> Path:
+        """키에 대한 경로 계산. | Resolve filesystem path for key."""
+        return self.base_path / f"{key}.json"
+
+    def store(self, key: str, payload: CacheData, timestamp: datetime | None = None) -> None:
+        """캐시를 저장. | Store cache payload."""
+        envelope = {
+            "timestamp": (timestamp or datetime.now(timezone.utc)).isoformat(),
+            "payload": payload,
+        }
+        self._resolve_path(key).write_text(
+            json.dumps(envelope, ensure_ascii=False), encoding="utf-8"
+        )
+
+    def load(self, key: str) -> CacheData | None:
+        """캐시를 로드. | Load cache payload."""
+        path = self._resolve_path(key)
+        if not path.exists():
+            return None
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            timestamp = datetime.fromisoformat(data["timestamp"])
+        except (json.JSONDecodeError, KeyError, ValueError):
+            return None
+        if datetime.now(timezone.utc) - timestamp > self.ttl:
+            return None
+        payload = data.get("payload")
+        if isinstance(payload, (dict, list)):
+            return payload
+        return None

--- a/src/wv/core/models.py
+++ b/src/wv/core/models.py
@@ -1,0 +1,47 @@
+"""도메인 모델 정의. | Define domain models."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class LogiBaseModel(BaseModel):
+    """로지스틱스 기본 모델 기반. | Logistics base model foundation."""
+
+    model_config = ConfigDict(populate_by_name=True, arbitrary_types_allowed=True)
+
+
+class RiskLevel(str, Enum):
+    """위험 수준 열거형. | Risk level enumeration."""
+
+    LOW = "Low"
+    MEDIUM = "Medium"
+    HIGH = "High"
+
+
+class ForecastPoint(LogiBaseModel):
+    """기상 예측 지점을 표현. | Represent a forecast point."""
+
+    time: datetime = Field(..., description="Timestamp of the forecast point")
+    lat: float = Field(..., description="Latitude")
+    lon: float = Field(..., description="Longitude")
+    hs: Optional[float] = Field(None, description="Significant wave height (m)")
+    tp: Optional[float] = Field(None, description="Peak period (s)")
+    dp: Optional[float] = Field(None, description="Wave direction (deg)")
+    wind_speed: Optional[float] = Field(None, description="Wind speed (kt)")
+    wind_dir: Optional[float] = Field(None, description="Wind direction (deg)")
+    swell_height: Optional[float] = Field(None, description="Swell height (m)")
+    swell_period: Optional[float] = Field(None, description="Swell period (s)")
+    swell_direction: Optional[float] = Field(None, description="Swell direction (deg)")
+
+
+class RiskAssessment(LogiBaseModel):
+    """위험 평가 결과를 담음. | Hold risk assessment result."""
+
+    level: RiskLevel
+    reasons: List[str]
+    metrics: Dict[str, str]

--- a/src/wv/core/risk.py
+++ b/src/wv/core/risk.py
@@ -1,0 +1,73 @@
+"""위험 평가 로직을 제공. | Provide risk assessment logic."""
+
+from __future__ import annotations
+
+import os
+from typing import Dict, List
+
+from .models import ForecastPoint, RiskAssessment, RiskLevel
+from .utils import format_metric
+
+
+def _env_float(name: str, default: float) -> float:
+    """환경 변수에서 부동 소수 값을 읽음. | Read float from environment variable."""
+    value = os.getenv(name)
+    if value is None:
+        return default
+    try:
+        return float(value)
+    except ValueError:
+        return default
+
+
+def compute_risk(point: ForecastPoint) -> RiskAssessment:
+    """예측 지점의 위험을 계산. | Compute risk for forecast point."""
+    medium_hs = _env_float("WV_MEDIUM_HS", 2.0)
+    high_hs = _env_float("WV_HIGH_HS", 3.0)
+    medium_wind = _env_float("WV_MEDIUM_WIND", 22.0)
+    high_wind = _env_float("WV_HIGH_WIND", 28.0)
+
+    level = RiskLevel.LOW
+    reasons: List[str] = []
+
+    hs = point.hs or point.swell_height
+    if hs is not None:
+        if hs > high_hs:
+            level = RiskLevel.HIGH
+            reasons.append(
+                f"Significant wave height {hs:.2f} m exceeds high threshold {high_hs:.2f} m"
+            )
+        elif hs > medium_hs and level != RiskLevel.HIGH:
+            level = RiskLevel.MEDIUM
+            reasons.append(
+                f"Significant wave height {hs:.2f} m exceeds medium threshold {medium_hs:.2f} m"
+            )
+
+    wind = point.wind_speed
+    if wind is not None:
+        if wind > high_wind:
+            level = RiskLevel.HIGH
+            reasons.append(f"Wind speed {wind:.2f} kt exceeds high threshold {high_wind:.2f} kt")
+        elif wind > medium_wind and level != RiskLevel.HIGH:
+            level = RiskLevel.MEDIUM
+            reasons.append(
+                f"Wind speed {wind:.2f} kt exceeds medium threshold {medium_wind:.2f} kt"
+            )
+
+    if point.swell_period is None or point.swell_direction is None:
+        level = RiskLevel.MEDIUM if level is RiskLevel.LOW else level
+        reasons.append("Missing swell inputs; conservative risk applied")
+
+    metrics: Dict[str, str] = {
+        "Hs": format_metric(point.hs, "m"),
+        "Wind": format_metric(point.wind_speed, "kt"),
+        "Wind Dir": format_metric(point.wind_dir, "deg"),
+        "Swell Hs": format_metric(point.swell_height, "m"),
+        "Swell Tp": format_metric(point.swell_period, "s"),
+        "Swell Dir": format_metric(point.swell_direction, "deg"),
+    }
+
+    if not reasons:
+        reasons.append("Conditions within defined safety thresholds")
+
+    return RiskAssessment(level=level, reasons=reasons, metrics=metrics)

--- a/src/wv/core/utils.py
+++ b/src/wv/core/utils.py
@@ -1,0 +1,16 @@
+"""공용 유틸리티를 제공. | Provide shared utilities."""
+
+from __future__ import annotations
+
+from decimal import ROUND_HALF_UP, Decimal
+
+
+def format_metric(value: float | None, unit: str | None = None) -> str:
+    """수치를 소수 둘째 자리까지 형식화. | Format value to two decimals."""
+    if value is None:
+        return "N/A"
+    quantized = Decimal(str(value)).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+    formatted = f"{quantized:.2f}"
+    if unit:
+        return f"{formatted} {unit}"
+    return formatted

--- a/src/wv/notify/email.py
+++ b/src/wv/notify/email.py
@@ -1,0 +1,67 @@
+"""이메일 알림 모듈. | Email notification module."""
+
+from __future__ import annotations
+
+import os
+import smtplib
+from email.message import EmailMessage
+from typing import Optional, Protocol, Sequence
+
+from wv.notify.manager import NotificationChannel
+
+
+class SupportsSendMessage(Protocol):
+    """SMTP 호환 객체 프로토콜. | Protocol for SMTP-like clients."""
+
+    def send_message(self, message: EmailMessage) -> None:
+        """메시지를 전송. | Send message."""
+
+
+class EmailNotifier(NotificationChannel):
+    """이메일 발송 도우미. | Helper for sending email."""
+
+    def __init__(
+        self,
+        smtp_client: Optional[SupportsSendMessage] | None = None,
+        sender: Optional[str] | None = None,
+        recipients: Optional[Sequence[str]] | None = None,
+    ) -> None:
+        self.sender = sender or os.getenv("WV_EMAIL_SENDER", "noreply@weather-vessel.local")
+        env_recipients = os.getenv("WV_EMAIL_RECIPIENTS", "")
+        if recipients is not None:
+            self.recipients = list(recipients)
+        elif env_recipients:
+            self.recipients = [item.strip() for item in env_recipients.split(",") if item.strip()]
+        else:
+            self.recipients = []
+        self.smtp_client = smtp_client
+
+    def _make_connection(self) -> smtplib.SMTP:
+        host = os.getenv("WV_SMTP_HOST", "localhost")
+        port = int(os.getenv("WV_SMTP_PORT", "25"))
+        username = os.getenv("WV_SMTP_USERNAME")
+        password = os.getenv("WV_SMTP_PASSWORD")
+        use_tls = os.getenv("WV_SMTP_TLS", "false").lower() in {"true", "1", "yes"}
+        client = smtplib.SMTP(host=host, port=port, timeout=10)
+        if use_tls:
+            client.starttls()
+        if username and password:
+            client.login(username, password)
+        return client
+
+    def send(self, subject: str, body: str) -> None:
+        """이메일을 발송. | Send an email."""
+        if not self.recipients:
+            return
+        message = EmailMessage()
+        message["Subject"] = subject
+        message["From"] = self.sender
+        message["To"] = ", ".join(self.recipients)
+        message.set_content(body)
+
+        if self.smtp_client is not None:
+            self.smtp_client.send_message(message)
+            return
+
+        with self._make_connection() as client:
+            client.send_message(message)

--- a/src/wv/notify/manager.py
+++ b/src/wv/notify/manager.py
@@ -1,0 +1,35 @@
+"""알림 채널 관리. | Manage notification channels."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import List, Sequence
+
+LOGGER = logging.getLogger("wv.notify")
+
+
+@dataclass(slots=True)
+class NotificationChannel:
+    """알림 채널 인터페이스. | Notification channel interface."""
+
+    def send(self, title: str, message: str) -> None:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+class NotificationManager:
+    """다중 채널 알림 관리자. | Multi-channel notification manager."""
+
+    def __init__(self, channels: Sequence[NotificationChannel]) -> None:
+        self.channels: List[NotificationChannel] = list(channels)
+
+    def send_all(self, title: str, message: str, dry_run: bool = False) -> None:
+        """모든 채널에 전송. | Send to all channels."""
+        if dry_run:
+            LOGGER.info("Dry run: %s - %s", title, message)
+            return
+        for channel in self.channels:
+            try:
+                channel.send(title, message)
+            except Exception as exc:  # pragma: no cover - logging path
+                LOGGER.error("Notification via %s failed: %s", channel.__class__.__name__, exc)

--- a/src/wv/notify/slack.py
+++ b/src/wv/notify/slack.py
@@ -1,0 +1,27 @@
+"""Slack 알림 모듈. | Slack notification module."""
+
+from __future__ import annotations
+
+import httpx
+
+from wv.notify.manager import NotificationChannel
+
+
+class SlackNotifier(NotificationChannel):
+    """Slack 웹훅 발송기. | Slack webhook sender."""
+
+    def __init__(self, webhook_url: str, client: httpx.Client | None = None) -> None:
+        self.webhook_url = webhook_url
+        self.client = client or httpx.Client()
+        self._owns_client = client is None
+
+    def __del__(self) -> None:
+        if getattr(self, "_owns_client", False):
+            self.client.close()
+
+    def send(self, title: str, message: str) -> None:
+        """Slack으로 메시지를 발송. | Send message to Slack."""
+        payload = {"text": f"*{title}*\n{message}"}
+        response = self.client.post(self.webhook_url, json=payload, timeout=10)
+        if response.status_code >= 400:
+            raise RuntimeError(f"Slack notification failed: {response.status_code}")

--- a/src/wv/notify/telegram.py
+++ b/src/wv/notify/telegram.py
@@ -1,0 +1,33 @@
+"""Telegram 알림 모듈. | Telegram notification module."""
+
+from __future__ import annotations
+
+import httpx
+
+from wv.notify.manager import NotificationChannel
+
+
+class TelegramNotifier(NotificationChannel):
+    """텔레그램 봇 발송기. | Telegram bot sender."""
+
+    def __init__(self, bot_token: str, chat_id: str, client: httpx.Client | None = None) -> None:
+        self.bot_token = bot_token
+        self.chat_id = chat_id
+        self.client = client or httpx.Client()
+        self._owns_client = client is None
+
+    def __del__(self) -> None:
+        if getattr(self, "_owns_client", False):
+            self.client.close()
+
+    def send(self, title: str, message: str) -> None:
+        """텔레그램으로 메시지를 발송. | Send message to Telegram."""
+        base_url = f"https://api.telegram.org/bot{self.bot_token}/sendMessage"
+        payload = {
+            "chat_id": self.chat_id,
+            "text": f"{title}\n{message}",
+            "parse_mode": "Markdown",
+        }
+        response = self.client.post(base_url, data=payload, timeout=10)
+        if response.status_code >= 400:
+            raise RuntimeError(f"Telegram notification failed: {response.status_code}")

--- a/src/wv/providers/base.py
+++ b/src/wv/providers/base.py
@@ -1,0 +1,39 @@
+"""프로바이더 기본 정의. | Define provider base classes."""
+
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass
+from typing import Iterable, List
+
+from wv.core.models import ForecastPoint
+
+
+class ProviderError(Exception):
+    """프로바이더 오류 기본. | Base provider error."""
+
+
+class ProviderRateLimitError(ProviderError):
+    """요청 한도 초과 오류. | Rate limit exceeded error."""
+
+
+class ProviderTimeoutError(ProviderError):
+    """타임아웃 오류. | Timeout error."""
+
+
+class MarineProvider(abc.ABC):
+    """해양 데이터 프로바이더 인터페이스. | Marine data provider interface."""
+
+    name: str
+
+    @abc.abstractmethod
+    def fetch(self, lat: float, lon: float, hours: int) -> List[ForecastPoint]:
+        """예측 데이터를 가져옴. | Fetch forecast data."""
+
+
+@dataclass(slots=True)
+class ProviderResult:
+    """프로바이더 결과와 출처. | Provider result with source."""
+
+    provider: MarineProvider
+    points: Iterable[ForecastPoint]

--- a/src/wv/providers/noaa_ww3.py
+++ b/src/wv/providers/noaa_ww3.py
@@ -1,0 +1,97 @@
+"""NOAA WaveWatch III 프로바이더. | NOAA WaveWatch III provider."""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from typing import Any, List, Optional
+
+import httpx
+
+from wv.core.models import ForecastPoint
+from wv.providers.base import (
+    MarineProvider,
+    ProviderError,
+    ProviderRateLimitError,
+    ProviderTimeoutError,
+)
+
+
+class NoaaWaveWatchProvider(MarineProvider):
+    """NOAA WW3 API 어댑터. | NOAA WW3 API adapter."""
+
+    name = "noaa_ww3"
+
+    def __init__(
+        self,
+        endpoint: Optional[str] | None = None,
+        client: Optional[httpx.Client] | None = None,
+        timeout: float = 10.0,
+    ) -> None:
+        self.endpoint: str = (
+            endpoint
+            or os.getenv("NOAA_WW3_ENDPOINT", "https://nomads.ncep.noaa.gov/api/noaa_ww3")
+            or "https://nomads.ncep.noaa.gov/api/noaa_ww3"
+        )
+        self._client = client or httpx.Client(timeout=timeout)
+        self._owns_client = client is None
+
+    def __del__(self) -> None:
+        if getattr(self, "_owns_client", False):
+            client = getattr(self, "_client", None)
+            if client is not None:
+                client.close()
+
+    def fetch(self, lat: float, lon: float, hours: int) -> List[ForecastPoint]:
+        """NOAA WaveWatch III 예측 조회. | Fetch NOAA WaveWatch III forecast."""
+        params = {"lat": f"{lat:.4f}", "lon": f"{lon:.4f}", "hours": str(hours)}
+        try:
+            response = self._client.get(self.endpoint, params=params)
+        except httpx.TimeoutException as exc:
+            raise ProviderTimeoutError("NOAA WW3 request timed out") from exc
+        except httpx.HTTPError as exc:
+            raise ProviderError(f"NOAA WW3 request failed: {exc}") from exc
+
+        if response.status_code == 429:
+            raise ProviderRateLimitError("NOAA WW3 rate limit exceeded")
+        if response.status_code >= 500:
+            raise ProviderError(f"NOAA WW3 server error {response.status_code}")
+        if response.status_code != 200:
+            raise ProviderError(f"NOAA WW3 unexpected status {response.status_code}")
+
+        payload = response.json()
+        records = payload.get("data", [])
+        points: List[ForecastPoint] = []
+        for record in records:
+            time_str = record.get("time")
+            if time_str is None:
+                continue
+            try:
+                timestamp = datetime.fromisoformat(time_str.replace("Z", "+00:00"))
+                if timestamp.tzinfo is None:
+                    timestamp = timestamp.replace(tzinfo=timezone.utc)
+            except ValueError:
+                continue
+            points.append(
+                ForecastPoint(
+                    time=timestamp,
+                    lat=lat,
+                    lon=lon,
+                    hs=_maybe_float(record.get("hs")),
+                    tp=_maybe_float(record.get("tp")),
+                    dp=_maybe_float(record.get("dp")),
+                    wind_speed=_maybe_float(record.get("wind")),
+                    wind_dir=_maybe_float(record.get("wind_dir")),
+                    swell_height=_maybe_float(record.get("swell_hs")),
+                    swell_period=_maybe_float(record.get("swell_tp")),
+                    swell_direction=_maybe_float(record.get("swell_dir")),
+                )
+            )
+        return points
+
+
+def _maybe_float(value: Any) -> Optional[float]:
+    """값을 부동소수로 변환. | Convert value to float."""
+    if isinstance(value, (int, float, str)):
+        return float(value)
+    return None

--- a/src/wv/providers/open_meteo.py
+++ b/src/wv/providers/open_meteo.py
@@ -1,0 +1,109 @@
+"""Open-Meteo 해양 데이터 어댑터. | Open-Meteo marine data adapter."""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from typing import Any, List, Optional, Sequence
+
+import httpx
+
+from wv.core.models import ForecastPoint
+from wv.providers.base import (
+    MarineProvider,
+    ProviderError,
+    ProviderRateLimitError,
+    ProviderTimeoutError,
+)
+
+
+class OpenMeteoMarineProvider(MarineProvider):
+    """Open-Meteo 마린 API 어댑터. | Open-Meteo marine API adapter."""
+
+    name = "open_meteo"
+
+    def __init__(
+        self,
+        endpoint: Optional[str] | None = None,
+        client: Optional[httpx.Client] | None = None,
+        timeout: float = 10.0,
+    ) -> None:
+        self.endpoint: str = (
+            endpoint
+            or os.getenv("OPEN_METEO_ENDPOINT", "https://marine-api.open-meteo.com/v1/marine")
+            or "https://marine-api.open-meteo.com/v1/marine"
+        )
+        self._client = client or httpx.Client(timeout=timeout)
+        self._owns_client = client is None
+
+    def __del__(self) -> None:
+        if getattr(self, "_owns_client", False):
+            client = getattr(self, "_client", None)
+            if client is not None:
+                client.close()
+
+    def fetch(self, lat: float, lon: float, hours: int) -> List[ForecastPoint]:
+        """Open-Meteo에서 예측을 조회. | Fetch forecast from Open-Meteo."""
+        params = {
+            "latitude": f"{lat:.4f}",
+            "longitude": f"{lon:.4f}",
+            "hourly": "wave_height,wind_speed,wind_direction,wave_direction,wave_period",
+            "forecast_hours": str(hours),
+        }
+        try:
+            response = self._client.get(self.endpoint, params=params)
+        except httpx.TimeoutException as exc:
+            raise ProviderTimeoutError("Open-Meteo request timed out") from exc
+        except httpx.HTTPError as exc:
+            raise ProviderError(f"Open-Meteo request failed: {exc}") from exc
+
+        if response.status_code == 429:
+            raise ProviderRateLimitError("Open-Meteo rate limit exceeded")
+        if response.status_code >= 500:
+            raise ProviderError(f"Open-Meteo server error {response.status_code}")
+        if response.status_code != 200:
+            raise ProviderError(f"Open-Meteo unexpected status {response.status_code}")
+
+        payload = response.json()
+        hourly = payload.get("hourly", {})
+        times: Sequence[str] = hourly.get("time", [])
+        heights: Sequence[Any] = hourly.get("wave_height", [])
+        wind_speeds: Sequence[Any] = hourly.get("wind_speed", [])
+        wind_dirs: Sequence[Any] = hourly.get("wind_direction", [])
+        wave_dirs: Sequence[Any] = hourly.get("wave_direction", [])
+        wave_periods: Sequence[Any] = hourly.get("wave_period", [])
+
+        points: List[ForecastPoint] = []
+        for index, time_str in enumerate(times):
+            try:
+                timestamp = datetime.fromisoformat(time_str.replace("Z", "+00:00"))
+                if timestamp.tzinfo is None:
+                    timestamp = timestamp.replace(tzinfo=timezone.utc)
+            except ValueError:
+                continue
+            points.append(
+                ForecastPoint(
+                    time=timestamp,
+                    lat=lat,
+                    lon=lon,
+                    hs=_safe_float(heights, index),
+                    tp=_safe_float(wave_periods, index),
+                    dp=_safe_float(wave_dirs, index),
+                    wind_speed=_safe_float(wind_speeds, index),
+                    wind_dir=_safe_float(wind_dirs, index),
+                    swell_height=None,
+                    swell_period=_safe_float(wave_periods, index),
+                    swell_direction=_safe_float(wave_dirs, index),
+                )
+            )
+        return points
+
+
+def _safe_float(values: Sequence[Any], index: int) -> Optional[float]:
+    """배열에서 안전하게 부동소수 추출. | Safely extract float from list."""
+    if index >= len(values):
+        return None
+    value = values[index]
+    if isinstance(value, (int, float, str)):
+        return float(value)
+    return None

--- a/src/wv/providers/stormglass.py
+++ b/src/wv/providers/stormglass.py
@@ -1,0 +1,112 @@
+"""Stormglass 해양 데이터 프로바이더. | Stormglass marine data provider."""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from wv.core.models import ForecastPoint
+from wv.providers.base import (
+    MarineProvider,
+    ProviderError,
+    ProviderRateLimitError,
+    ProviderTimeoutError,
+)
+
+
+class StormglassProvider(MarineProvider):
+    """Stormglass API 어댑터. | Stormglass API adapter."""
+
+    name = "stormglass"
+
+    def __init__(
+        self,
+        api_key: Optional[str] | None = None,
+        endpoint: Optional[str] | None = None,
+        client: Optional[httpx.Client] | None = None,
+        timeout: float = 10.0,
+    ) -> None:
+        self.api_key = api_key or os.getenv("STORMGLASS_API_KEY") or ""
+        self.endpoint: str = (
+            endpoint
+            or os.getenv("STORMGLASS_ENDPOINT", "https://api.stormglass.io/v2/weather/point")
+            or "https://api.stormglass.io/v2/weather/point"
+        )
+        self._client = client or httpx.Client(timeout=timeout)
+        self._owns_client = client is None
+
+    def __del__(self) -> None:
+        if getattr(self, "_owns_client", False):
+            client = getattr(self, "_client", None)
+            if client is not None:
+                client.close()
+
+    def fetch(self, lat: float, lon: float, hours: int) -> List[ForecastPoint]:
+        """Stormglass에서 예측을 조회. | Fetch forecast from Stormglass."""
+        end_time = datetime.now(timezone.utc) + timedelta(hours=hours)
+        params = {
+            "lat": f"{lat:.4f}",
+            "lng": f"{lon:.4f}",
+            "params": "waveHeight,wavePeriod,waveDirection,windSpeed,windDirection",
+            "start": datetime.now(timezone.utc).isoformat(),
+            "end": end_time.isoformat(),
+            "source": "sg",
+        }
+        headers = {"Authorization": self.api_key} if self.api_key else {}
+        try:
+            response = self._client.get(self.endpoint, params=params, headers=headers)
+        except httpx.TimeoutException as exc:
+            raise ProviderTimeoutError("Stormglass request timed out") from exc
+        except httpx.HTTPError as exc:
+            raise ProviderError(f"Stormglass request failed: {exc}") from exc
+
+        if response.status_code == 429:
+            raise ProviderRateLimitError("Stormglass rate limit exceeded")
+        if response.status_code >= 500:
+            raise ProviderError(f"Stormglass server error {response.status_code}")
+        if response.status_code != 200:
+            raise ProviderError(f"Stormglass unexpected status {response.status_code}")
+
+        payload = response.json()
+        hours_data = payload.get("hours", [])
+        points: List[ForecastPoint] = []
+        for item in hours_data:
+            time_str = item.get("time")
+            if time_str is None:
+                continue
+            try:
+                timestamp = datetime.fromisoformat(time_str.replace("Z", "+00:00"))
+            except ValueError:
+                continue
+            points.append(
+                ForecastPoint(
+                    time=timestamp,
+                    lat=lat,
+                    lon=lon,
+                    hs=_nested(item, "waveHeight"),
+                    tp=_nested(item, "wavePeriod"),
+                    dp=_nested(item, "waveDirection"),
+                    wind_speed=_nested(item, "windSpeed"),
+                    wind_dir=_nested(item, "windDirection"),
+                    swell_height=_nested(item, "swellHeight"),
+                    swell_period=_nested(item, "swellPeriod"),
+                    swell_direction=_nested(item, "swellDirection"),
+                )
+            )
+        return points
+
+
+def _nested(data: Dict[str, Any], key: str) -> Optional[float]:
+    """중첩된 sg 키를 추출. | Extract nested sg key."""
+    value = data.get(key)
+    if isinstance(value, dict):
+        inner = value.get("sg")
+        if isinstance(inner, (int, float, str)):
+            return float(inner)
+        return None
+    if isinstance(value, (int, float, str)):
+        return float(value)
+    return None

--- a/src/wv/services/autocheck.py
+++ b/src/wv/services/autocheck.py
@@ -1,0 +1,65 @@
+"""자동 위험 점검 스케줄러. | Auto risk check scheduler."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Mapping, Protocol, Sequence, Tuple
+from zoneinfo import ZoneInfo
+
+from wv.core.models import ForecastPoint
+from wv.core.risk import compute_risk
+from wv.core.utils import format_metric
+
+
+class MarineServiceProtocol(Protocol):
+    """해양 서비스 인터페이스. | Marine service interface."""
+
+    def get_forecast(self, lat: float, lon: float, hours: int = 48) -> Sequence[ForecastPoint]:
+        """예측을 반환. | Return forecast."""
+
+
+class NotificationClient(Protocol):
+    """알림 클라이언트 인터페이스. | Notification client interface."""
+
+    def send_all(self, title: str, message: str, dry_run: bool = False) -> None:
+        """알림을 전송. | Send notifications."""
+
+
+class AutoCheckScheduler:
+    """정시 알림을 실행. | Execute scheduled notifications."""
+
+    def __init__(
+        self,
+        marine_service: MarineServiceProtocol,
+        notifier: NotificationClient,
+        routes: Mapping[str, Tuple[float, float]],
+        timezone_name: str = "Asia/Dubai",
+    ) -> None:
+        self.marine_service = marine_service
+        self.notifier = notifier
+        self.routes = dict(routes)
+        self.tz = ZoneInfo(timezone_name)
+
+    def _is_window(self, moment: datetime) -> bool:
+        local = moment.astimezone(self.tz)
+        return local.minute == 0 and local.hour in {6, 17}
+
+    def run_pending(self, now: datetime | None = None) -> None:
+        """예약된 작업을 실행. | Run pending jobs."""
+        moment = now or datetime.now(timezone.utc)
+        if not self._is_window(moment):
+            return
+        for route, coords in self.routes.items():
+            lat, lon = coords
+            points = self.marine_service.get_forecast(lat=lat, lon=lon, hours=48)
+            if not points:
+                continue
+            assessment = compute_risk(points[0])
+            subject = f"Scheduled marine risk - {route}"
+            body = (
+                f"Risk Level: {assessment.level.value}\n"
+                f"Hs: {format_metric(points[0].hs, 'm')}\n"
+                f"Wind: {format_metric(points[0].wind_speed, 'kt')}\n"
+                f"Reasons: {', '.join(assessment.reasons)}"
+            )
+            self.notifier.send_all(subject, body, dry_run=False)

--- a/src/wv/services/marine.py
+++ b/src/wv/services/marine.py
@@ -1,0 +1,63 @@
+"""해양 예측 서비스. | Marine forecast service."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, List, Sequence
+
+from wv.core.cache import CacheRepository
+from wv.core.models import ForecastPoint
+from wv.providers.base import (
+    MarineProvider,
+    ProviderError,
+    ProviderRateLimitError,
+    ProviderTimeoutError,
+)
+
+LOGGER = logging.getLogger("wv.marine")
+
+
+class MarineForecastService:
+    """프로바이더 순환 예측 서비스. | Forecast service rotating providers."""
+
+    def __init__(
+        self,
+        providers: Sequence[MarineProvider],
+        cache: CacheRepository,
+    ) -> None:
+        self.providers = list(providers)
+        self.cache = cache
+
+    def get_forecast(self, lat: float, lon: float, hours: int = 48) -> List[ForecastPoint]:
+        """예측 데이터를 취득. | Acquire forecast data."""
+        params = {"lat": lat, "lon": lon, "hours": hours}
+        for provider in self.providers:
+            key = self.cache.make_key(provider.name, params)
+            try:
+                points = provider.fetch(lat=lat, lon=lon, hours=hours)
+            except ProviderRateLimitError:
+                LOGGER.warning("Provider %s rate limited; trying fallback", provider.name)
+                continue
+            except ProviderTimeoutError:
+                LOGGER.warning("Provider %s timed out; trying fallback", provider.name)
+                continue
+            except ProviderError as exc:
+                LOGGER.warning("Provider %s failed: %s", provider.name, exc)
+                continue
+            if points:
+                payload: List[dict[str, Any]] = [point.model_dump(mode="json") for point in points]
+                self.cache.store(
+                    key,
+                    payload=payload,
+                )
+                return list(points)
+
+        # fallback to cache entries within TTL
+        for provider in self.providers:
+            key = self.cache.make_key(provider.name, params)
+            cached = self.cache.load(key)
+            if cached:
+                LOGGER.info("Using cached data for provider %s", provider.name)
+                return [ForecastPoint.model_validate(item) for item in cached]
+
+        raise ProviderError("No marine forecast data available")

--- a/src/wv/services/scheduler.py
+++ b/src/wv/services/scheduler.py
@@ -1,0 +1,205 @@
+"""항해 스케줄러 서비스. | Voyage scheduler service."""
+
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Iterable, List, Optional, Protocol
+from uuid import uuid4
+from zoneinfo import ZoneInfo
+
+from wv.core.models import ForecastPoint, RiskLevel
+from wv.core.risk import compute_risk
+from wv.core.utils import format_metric
+
+RISK_ORDER = {RiskLevel.LOW: 0, RiskLevel.MEDIUM: 1, RiskLevel.HIGH: 2}
+
+
+@dataclass(slots=True)
+class ScheduleEntry:
+    """주간 일정 항목. | Weekly schedule entry."""
+
+    date: datetime
+    etd: datetime
+    eta: datetime
+    risk: RiskLevel
+    reason: str
+    avg_hs: float | None
+    avg_wind: float | None
+
+
+class MarineServiceProtocol(Protocol):
+    """해양 서비스 프로토콜. | Protocol for marine service."""
+
+    def get_forecast(self, lat: float, lon: float, hours: int = 48) -> List[ForecastPoint]:
+        """예측을 반환. | Return forecast."""
+
+
+class VoyageScheduler:
+    """주간 항해 일정 생성기. | Weekly voyage schedule generator."""
+
+    def __init__(
+        self,
+        marine_service: MarineServiceProtocol,
+        output_dir: Optional[Path] | None = None,
+        timezone_name: str = "Asia/Dubai",
+    ) -> None:
+        self.marine_service = marine_service
+        self.tz = ZoneInfo(timezone_name)
+        self.output_dir = Path(output_dir or Path("outputs"))
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+    def generate_weekly_schedule(
+        self,
+        lat: float,
+        lon: float,
+        vessel_speed: float | None = None,
+        route_distance_nm: float | None = None,
+        cargo_hs_limit: float | None = None,
+    ) -> str:
+        """7일 항해 일정을 생성. | Generate seven-day voyage schedule."""
+        points = self.marine_service.get_forecast(lat=lat, lon=lon, hours=168)
+        entries = self._build_entries(points, vessel_speed, route_distance_nm, cargo_hs_limit)
+        self._write_csv(entries)
+        self._write_ics(entries)
+        return self._format_table(entries)
+
+    def _build_entries(
+        self,
+        points: Iterable[ForecastPoint],
+        vessel_speed: float | None,
+        route_distance_nm: float | None,
+        cargo_hs_limit: float | None,
+    ) -> List[ScheduleEntry]:
+        points_list = list(points)
+        if not points_list:
+            return []
+        local_now = datetime.now(timezone.utc).astimezone(self.tz)
+        earliest_local = min(points_list, key=lambda item: item.time).time.astimezone(self.tz)
+        anchor = earliest_local if earliest_local < local_now else local_now
+        start_of_day = anchor.replace(hour=0, minute=0, second=0, microsecond=0)
+        points_by_day: dict[str, List[ForecastPoint]] = {}
+        for point in points_list:
+            local_time = point.time.astimezone(self.tz)
+            key = local_time.date().isoformat()
+            points_by_day.setdefault(key, []).append(point)
+
+        entries: List[ScheduleEntry] = []
+        for offset in range(7):
+            day_start = start_of_day + timedelta(days=offset)
+            day_key = day_start.date().isoformat()
+            day_points = points_by_day.get(day_key, [])
+            if not day_points:
+                continue
+            avg_hs = _average([p.hs for p in day_points if p.hs is not None])
+            avg_wind = _average([p.wind_speed for p in day_points if p.wind_speed is not None])
+
+            risk, reason = self._daily_risk(day_points, cargo_hs_limit, avg_hs)
+
+            etd = day_start.replace(hour=6)
+            eta = etd + self._transit_duration(vessel_speed, route_distance_nm)
+            entries.append(
+                ScheduleEntry(
+                    date=day_start,
+                    etd=etd,
+                    eta=eta,
+                    risk=risk,
+                    reason=reason,
+                    avg_hs=avg_hs,
+                    avg_wind=avg_wind,
+                )
+            )
+        return entries
+
+    def _daily_risk(
+        self,
+        day_points: List[ForecastPoint],
+        cargo_hs_limit: float | None,
+        avg_hs: float | None,
+    ) -> tuple[RiskLevel, str]:
+        highest = RiskLevel.LOW
+        chosen_reason = "Conditions within defined safety thresholds"
+        for point in day_points:
+            assessment = compute_risk(point)
+            if RISK_ORDER[assessment.level] > RISK_ORDER[highest]:
+                highest = assessment.level
+                chosen_reason = "; ".join(assessment.reasons)
+        if cargo_hs_limit is not None and avg_hs is not None and avg_hs > cargo_hs_limit:
+            highest = RiskLevel.HIGH
+            chosen_reason = f"Average Hs {avg_hs:.2f} m exceeds cargo limit {cargo_hs_limit:.2f} m"
+        return highest, chosen_reason
+
+    def _transit_duration(
+        self,
+        vessel_speed: float | None,
+        route_distance_nm: float | None,
+    ) -> timedelta:
+        if vessel_speed and route_distance_nm and vessel_speed > 0:
+            hours = route_distance_nm / vessel_speed
+            return timedelta(hours=hours)
+        return timedelta(hours=12)
+
+    def _write_csv(self, entries: Iterable[ScheduleEntry]) -> None:
+        path = self.output_dir / "schedule_week.csv"
+        with path.open("w", encoding="utf-8", newline="") as handle:
+            writer = csv.writer(handle)
+            writer.writerow(["Date", "ETD", "ETA", "Hs(m)", "Wind(kt)", "Risk", "Reason"])
+            for entry in entries:
+                writer.writerow(
+                    [
+                        entry.date.astimezone(self.tz).strftime("%Y-%m-%d"),
+                        entry.etd.astimezone(self.tz).strftime("%Y-%m-%d %H:%M"),
+                        entry.eta.astimezone(self.tz).strftime("%Y-%m-%d %H:%M"),
+                        format_metric(entry.avg_hs, "m"),
+                        format_metric(entry.avg_wind, "kt"),
+                        entry.risk.value,
+                        entry.reason,
+                    ]
+                )
+
+    def _write_ics(self, entries: Iterable[ScheduleEntry]) -> None:
+        path = self.output_dir / "schedule_week.ics"
+        lines = ["BEGIN:VCALENDAR", "VERSION:2.0", "PRODID:-//WEATHER-VESSEL//SCHEDULE//EN"]
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        for entry in entries:
+            uid = uuid4().hex
+            lines.extend(
+                [
+                    "BEGIN:VEVENT",
+                    f"UID:{uid}@weather-vessel",
+                    f"DTSTAMP:{timestamp}",
+                    f"DTSTART:{entry.etd.astimezone(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}",
+                    f"DTEND:{entry.eta.astimezone(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}",
+                    f"SUMMARY:Voyage slot - {entry.risk.value} risk",
+                    f"DESCRIPTION:{entry.reason}",
+                    "END:VEVENT",
+                ]
+            )
+        lines.append("END:VCALENDAR")
+        path.write_text("\n".join(lines), encoding="utf-8")
+
+    def _format_table(self, entries: Iterable[ScheduleEntry]) -> str:
+        header = "Weekly Voyage Schedule (Asia/Dubai)\n"
+        divider = "=" * 90
+        lines = [header, divider]
+        lines.append(f"{'Date':<12}{'ETD':<20}{'ETA':<20}{'Hs':<10}{'Wind':<10}{'Risk':<8}Reason")
+        for entry in entries:
+            lines.append(
+                f"{entry.date.astimezone(self.tz).strftime('%Y-%m-%d'):<12}"
+                f"{entry.etd.astimezone(self.tz).strftime('%m-%d %H:%M'):<20}"
+                f"{entry.eta.astimezone(self.tz).strftime('%m-%d %H:%M'):<20}"
+                f"{format_metric(entry.avg_hs, 'm'):<10}"
+                f"{format_metric(entry.avg_wind, 'kt'):<10}"
+                f"{entry.risk.value:<8}{entry.reason}"
+            )
+        return "\n".join(lines)
+
+
+def _average(values: Iterable[float]) -> float | None:
+    """평균을 계산. | Compute average."""
+    values_list = [value for value in values]
+    if not values_list:
+        return None
+    return sum(values_list) / len(values_list)

--- a/src/wv/version.py
+++ b/src/wv/version.py
@@ -1,0 +1,3 @@
+"""버전 정보를 제공. | Provide version information."""
+
+__version__ = "0.1.0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))

--- a/tests/notify/test_channels.py
+++ b/tests/notify/test_channels.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from email.message import EmailMessage
+from typing import List
+
+import httpx
+
+from wv.notify.email import EmailNotifier
+from wv.notify.manager import NotificationManager
+from wv.notify.slack import SlackNotifier
+from wv.notify.telegram import TelegramNotifier
+
+
+class DummySMTP:
+    def __init__(self) -> None:
+        self.sent: List[EmailMessage] = []
+
+    def send_message(self, message: EmailMessage) -> None:  # pragma: no cover - simple forwarding
+        self.sent.append(message)
+
+
+def test_email_notifier_sends_message() -> None:
+    smtp = DummySMTP()
+    notifier = EmailNotifier(
+        smtp_client=smtp,
+        sender="ops@example.com",
+        recipients=["captain@example.com"],
+    )
+    notifier.send("Route MW4-AGI", "Hs 1.20 m, Wind 12.00 kt")
+    assert len(smtp.sent) == 1
+    assert smtp.sent[0]["Subject"] == "Route MW4-AGI"
+
+
+def test_slack_notifier_posts_message() -> None:
+    captured: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = request.content.decode()
+        return httpx.Response(status_code=200)
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    notifier = SlackNotifier(webhook_url="https://hooks.slack.com/test", client=client)
+    notifier.send("Alert", "Hs 3.10 m")
+    assert "Hs 3.10 m" in captured["body"]
+
+
+def test_telegram_notifier_posts_message() -> None:
+    captured: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        return httpx.Response(status_code=200)
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    notifier = TelegramNotifier(bot_token="token", chat_id="123", client=client)
+    notifier.send("Alert", "Wind 28.00 kt")
+    assert "sendMessage" in captured["url"]
+
+
+def test_notification_manager_dispatches_all_channels() -> None:
+    smtp = DummySMTP()
+    slack_body: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        slack_body["body"] = request.content.decode()
+        return httpx.Response(status_code=200)
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    manager = NotificationManager(
+        channels=[
+            EmailNotifier(
+                smtp_client=smtp, sender="ops@example.com", recipients=["captain@example.com"]
+            ),
+            SlackNotifier(webhook_url="https://hooks.slack.com/test", client=client),
+        ]
+    )
+    manager.send_all("Alert", "Combined alert")
+    assert smtp.sent
+    assert "Combined alert" in slack_body["body"]

--- a/tests/providers/test_marine_service.py
+++ b/tests/providers/test_marine_service.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import List
+
+import httpx
+import pytest
+
+from wv.core.cache import CacheRepository
+from wv.core.models import ForecastPoint
+from wv.providers.base import ProviderError
+from wv.providers.noaa_ww3 import NoaaWaveWatchProvider
+from wv.providers.open_meteo import OpenMeteoMarineProvider
+from wv.providers.stormglass import StormglassProvider
+from wv.services.marine import MarineForecastService
+
+
+def _make_client(response: httpx.Response) -> httpx.Client:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return response
+
+    transport = httpx.MockTransport(handler)
+    return httpx.Client(transport=transport)
+
+
+def test_service_uses_primary_provider(tmp_path) -> None:
+    response = httpx.Response(
+        status_code=200,
+        json={
+            "hours": [
+                {
+                    "time": "2024-03-01T00:00:00+00:00",
+                    "waveHeight": {"sg": 1.2},
+                    "wavePeriod": {"sg": 10.0},
+                    "waveDirection": {"sg": 180.0},
+                    "windSpeed": {"sg": 5.0},
+                    "windDirection": {"sg": 90.0},
+                }
+            ]
+        },
+    )
+    provider = StormglassProvider(api_key="test", client=_make_client(response))
+    service = MarineForecastService(
+        providers=[provider],
+        cache=CacheRepository(base_path=tmp_path),
+    )
+    points = service.get_forecast(lat=24.3, lon=54.4, hours=6)
+    assert len(points) == 1
+    assert isinstance(points[0], ForecastPoint)
+    assert points[0].hs == pytest.approx(1.2)
+
+
+def test_service_falls_back_on_rate_limit(tmp_path) -> None:
+    limited_provider = StormglassProvider(
+        api_key="test",
+        client=_make_client(httpx.Response(status_code=429)),
+    )
+    fallback_response = httpx.Response(
+        status_code=200,
+        json={
+            "hourly": {
+                "time": ["2024-03-01T00:00"],
+                "wave_height": [1.5],
+                "wind_speed": [12.0],
+                "wind_direction": [135.0],
+                "wave_period": [9.0],
+                "wave_direction": [200.0],
+            }
+        },
+    )
+    fallback_provider = OpenMeteoMarineProvider(client=_make_client(fallback_response))
+    service = MarineForecastService(
+        providers=[limited_provider, fallback_provider],
+        cache=CacheRepository(base_path=tmp_path),
+    )
+    points = service.get_forecast(lat=24.3, lon=54.4, hours=6)
+    assert len(points) == 1
+    assert points[0].hs == pytest.approx(1.5)
+
+
+def test_service_returns_cache_when_all_fail(tmp_path) -> None:
+    cache = CacheRepository(base_path=tmp_path)
+    key = cache.make_key("stormglass", {"lat": 24.3, "lon": 54.4, "hours": 6})
+    cached_point = ForecastPoint(
+        time=datetime(2024, 3, 1, tzinfo=timezone.utc),
+        lat=24.3,
+        lon=54.4,
+        hs=1.8,
+        tp=10.0,
+        dp=190.0,
+        wind_speed=14.0,
+        wind_dir=100.0,
+        swell_height=1.8,
+        swell_period=10.0,
+        swell_direction=200.0,
+    )
+    cache.store(
+        key,
+        payload=[cached_point.model_dump(mode="json")],
+        timestamp=datetime.now(timezone.utc) - timedelta(minutes=30),
+    )
+
+    class BrokenProvider(StormglassProvider):
+        def __init__(self) -> None:
+            pass
+
+        def fetch(self, lat: float, lon: float, hours: int) -> List[ForecastPoint]:
+            raise ProviderError("boom")
+
+    service = MarineForecastService(
+        providers=[
+            BrokenProvider(),
+            NoaaWaveWatchProvider(client=_make_client(httpx.Response(status_code=500))),
+        ],
+        cache=cache,
+    )
+    points = service.get_forecast(lat=24.3, lon=54.4, hours=6)
+    assert len(points) == 1
+    assert points[0].hs == pytest.approx(1.8)

--- a/tests/services/test_autocheck.py
+++ b/tests/services/test_autocheck.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import List
+
+from wv.core.models import ForecastPoint
+from wv.services.autocheck import AutoCheckScheduler
+
+
+class DummyService:
+    def __init__(self, points: List[ForecastPoint]) -> None:
+        self.points = points
+        self.calls = 0
+
+    def get_forecast(self, lat: float, lon: float, hours: int = 48):
+        self.calls += 1
+        return self.points
+
+
+class DummyNotifier:
+    def __init__(self) -> None:
+        self.messages: List[str] = []
+
+    def send_all(self, title: str, message: str, dry_run: bool = False) -> None:
+        if not dry_run:
+            self.messages.append(f"{title}|{message}")
+
+
+def _point() -> ForecastPoint:
+    return ForecastPoint(
+        time=datetime(2024, 3, 1, 2, 0, tzinfo=timezone.utc),
+        lat=24.3,
+        lon=54.4,
+        hs=1.8,
+        tp=10.0,
+        dp=180.0,
+        wind_speed=18.0,
+        wind_dir=120.0,
+        swell_height=1.5,
+        swell_period=11.0,
+        swell_direction=200.0,
+    )
+
+
+def test_autocheck_runs_at_scheduled_time() -> None:
+    service = DummyService([_point()])
+    notifier = DummyNotifier()
+    scheduler = AutoCheckScheduler(
+        marine_service=service,
+        notifier=notifier,
+        routes={"MW4-AGI": (24.3488, 54.4651)},
+    )
+    now = datetime(2024, 3, 1, 2, 0, tzinfo=timezone.utc)  # 06:00 Asia/Dubai
+    scheduler.run_pending(now=now)
+    assert notifier.messages
+    assert "MW4-AGI" in notifier.messages[0]
+
+
+def test_autocheck_skips_non_window() -> None:
+    service = DummyService([_point()])
+    notifier = DummyNotifier()
+    scheduler = AutoCheckScheduler(
+        marine_service=service,
+        notifier=notifier,
+        routes={"MW4-AGI": (24.3488, 54.4651)},
+    )
+    now = datetime(2024, 3, 1, 5, 0, tzinfo=timezone.utc)  # 09:00 Asia/Dubai
+    scheduler.run_pending(now=now)
+    assert not notifier.messages

--- a/tests/services/test_scheduler.py
+++ b/tests/services/test_scheduler.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import List
+
+import pytest
+
+from wv.core.models import ForecastPoint
+from wv.services.scheduler import VoyageScheduler
+
+
+class FakeMarineService:
+    def __init__(self, points: List[ForecastPoint]) -> None:
+        self._points = points
+
+    def get_forecast(self, lat: float, lon: float, hours: int = 48) -> List[ForecastPoint]:
+        return self._points
+
+
+@pytest.fixture
+def forecast_points() -> List[ForecastPoint]:
+    base = datetime(2024, 3, 1, 0, 0, tzinfo=timezone.utc)
+    points: List[ForecastPoint] = []
+    for day in range(7):
+        timestamp = base + timedelta(days=day, hours=6)
+        points.append(
+            ForecastPoint(
+                time=timestamp,
+                lat=24.3,
+                lon=54.4,
+                hs=1.5 + day * 0.2,
+                tp=10.0,
+                dp=180.0,
+                wind_speed=15.0 + day,
+                wind_dir=100.0,
+                swell_height=1.2 + day * 0.2,
+                swell_period=12.0,
+                swell_direction=190.0,
+            )
+        )
+    return points
+
+
+def test_generate_weekly_schedule_outputs_files(
+    tmp_path: Path, forecast_points: List[ForecastPoint]
+) -> None:
+    service = FakeMarineService(forecast_points)
+    scheduler = VoyageScheduler(
+        marine_service=service,
+        output_dir=tmp_path,
+    )
+    table = scheduler.generate_weekly_schedule(
+        lat=24.3,
+        lon=54.4,
+        vessel_speed=12.0,
+        route_distance_nm=120.0,
+        cargo_hs_limit=2.5,
+    )
+    assert "Asia/Dubai" in table
+    csv_path = tmp_path / "schedule_week.csv"
+    ics_path = tmp_path / "schedule_week.ics"
+    assert csv_path.exists()
+    assert ics_path.exists()
+    csv_content = csv_path.read_text(encoding="utf-8")
+    assert "Risk" in csv_content
+    ics_content = ics_path.read_text(encoding="utf-8")
+    assert "BEGIN:VEVENT" in ics_content
+
+
+def test_schedule_respects_cargo_limit(
+    tmp_path: Path, forecast_points: List[ForecastPoint]
+) -> None:
+    service = FakeMarineService(forecast_points)
+    scheduler = VoyageScheduler(marine_service=service, output_dir=tmp_path)
+    table = scheduler.generate_weekly_schedule(
+        lat=24.3,
+        lon=54.4,
+        vessel_speed=12.0,
+        route_distance_nm=120.0,
+        cargo_hs_limit=1.6,
+    )
+    assert "High" in table or "Medium" in table

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,37 @@
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from wv.core.cache import CacheRepository
+
+
+def test_cache_repository_writes_and_reads(tmp_path: Path) -> None:
+    repo = CacheRepository(base_path=tmp_path, ttl=timedelta(hours=3))
+    key = repo.make_key("stormglass", {"lat": 24.3, "lon": 54.4})
+    payload = {"hs": 1.2}
+    repo.store(key, payload)
+    cached = repo.load(key)
+    assert cached == payload
+
+
+def test_cache_repository_respects_ttl(tmp_path: Path) -> None:
+    repo = CacheRepository(base_path=tmp_path, ttl=timedelta(hours=3))
+    key = repo.make_key("stormglass", {"lat": 24.3, "lon": 54.4})
+    payload = {"hs": 1.2, "timestamp": datetime.now(timezone.utc).isoformat()}
+    repo.store(key, payload, timestamp=datetime.now(timezone.utc) - timedelta(hours=4))
+    assert repo.load(key) is None
+
+
+def test_cache_repository_handles_missing_file(tmp_path: Path) -> None:
+    repo = CacheRepository(base_path=tmp_path, ttl=timedelta(hours=3))
+    key = repo.make_key("stormglass", {"lat": 24.3, "lon": 54.4})
+    assert repo.load(key) is None
+
+
+@pytest.mark.parametrize("provider", ["stormglass", "open_meteo", "noaa_ww3"])
+def test_cache_keys_are_unique_per_provider(tmp_path: Path, provider: str) -> None:
+    repo = CacheRepository(base_path=tmp_path, ttl=timedelta(hours=3))
+    key_one = repo.make_key(provider, {"lat": 24.3})
+    key_two = repo.make_key(provider, {"lat": 24.31})
+    assert key_one != key_two

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List
+
+from typer.testing import CliRunner
+
+from wv.cli import app
+from wv.core.models import ForecastPoint
+
+
+class DummyContainer:
+    def __init__(self, points: List[ForecastPoint], output_dir: Path) -> None:
+        self.points = points
+        self.output_dir = output_dir
+
+    def marine_service(self):
+        return self
+
+    def scheduler(self):
+        from wv.services.scheduler import VoyageScheduler
+
+        return VoyageScheduler(marine_service=self, output_dir=self.output_dir)
+
+    def notifier(self):
+        from wv.notify.manager import NotificationManager
+
+        return NotificationManager(channels=[])
+
+    # Methods consumed by CLI
+    def get_forecast(self, lat: float, lon: float, hours: int = 48):
+        return self.points
+
+    def send_notifications(self, subject: str, body: str) -> None:
+        pass
+
+
+runner = CliRunner()
+
+
+def _make_point() -> ForecastPoint:
+    return ForecastPoint(
+        time=datetime.now(timezone.utc),
+        lat=24.3,
+        lon=54.4,
+        hs=2.2,
+        tp=9.0,
+        dp=180.0,
+        wind_speed=25.0,
+        wind_dir=120.0,
+        swell_height=2.0,
+        swell_period=11.0,
+        swell_direction=200.0,
+    )
+
+
+def test_cli_check_now(monkeypatch, tmp_path: Path) -> None:
+    container = DummyContainer(points=[_make_point()], output_dir=tmp_path)
+
+    def fake_container() -> DummyContainer:
+        return container
+
+    monkeypatch.setattr("wv.cli.build_service_container", fake_container)
+    result = runner.invoke(app, ["check", "--now", "--lat", "24.3", "--lon", "54.4"])
+    assert result.exit_code == 0
+    assert "Risk" in result.stdout
+
+
+def test_cli_schedule_week_creates_outputs(monkeypatch, tmp_path: Path) -> None:
+    container = DummyContainer(points=[_make_point()], output_dir=tmp_path)
+
+    def fake_container() -> DummyContainer:
+        return container
+
+    monkeypatch.setattr("wv.cli.build_service_container", fake_container)
+    result = runner.invoke(app, ["schedule", "--week", "--lat", "24.3", "--lon", "54.4"])
+    assert result.exit_code == 0
+    assert (tmp_path / "schedule_week.csv").exists()
+    assert (tmp_path / "schedule_week.ics").exists()
+
+
+def test_cli_notify_dry_run(monkeypatch, tmp_path: Path) -> None:
+    container = DummyContainer(points=[_make_point()], output_dir=tmp_path)
+
+    def fake_container() -> DummyContainer:
+        return container
+
+    monkeypatch.setattr("wv.cli.build_service_container", fake_container)
+    result = runner.invoke(app, ["notify", "--route", "MW4-AGI", "--dry-run"])
+    assert result.exit_code == 0
+    assert "Dry run" in result.stdout

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -1,0 +1,105 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from wv.core.models import ForecastPoint
+from wv.core.risk import RiskAssessment, RiskLevel, compute_risk
+from wv.core.utils import format_metric
+
+
+def test_format_metric_two_decimals():
+    assert format_metric(1.234) == "1.23"
+    assert format_metric(5) == "5.00"
+
+
+@pytest.mark.parametrize(
+    "hs,wind,risk_level",
+    [
+        (1.99, 21.9, RiskLevel.LOW),
+        (2.01, 10.0, RiskLevel.MEDIUM),
+        (0.5, 28.5, RiskLevel.HIGH),
+        (3.5, 15.0, RiskLevel.HIGH),
+    ],
+)
+def test_compute_risk_thresholds(hs: float, wind: float, risk_level: RiskLevel) -> None:
+    point = ForecastPoint(
+        time=datetime.now(timezone.utc),
+        lat=24.3,
+        lon=54.4,
+        hs=hs,
+        tp=10.0,
+        dp=180.0,
+        wind_speed=wind,
+        wind_dir=90.0,
+        swell_height=hs,
+        swell_period=11.0,
+        swell_direction=200.0,
+    )
+    assessment = compute_risk(point)
+    assert assessment.level is risk_level
+
+
+def test_compute_risk_missing_swell_is_conservative(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("WV_MEDIUM_HS", "2.0")
+    monkeypatch.setenv("WV_HIGH_HS", "3.0")
+    point = ForecastPoint(
+        time=datetime.now(timezone.utc),
+        lat=24.3,
+        lon=54.4,
+        hs=1.5,
+        tp=None,
+        dp=None,
+        wind_speed=10.0,
+        wind_dir=45.0,
+        swell_height=None,
+        swell_period=None,
+        swell_direction=None,
+    )
+    assessment = compute_risk(point)
+    assert assessment.level is RiskLevel.MEDIUM
+    assert "Missing swell" in assessment.reasons[0]
+
+
+def test_risk_assessment_metrics_are_formatted() -> None:
+    point = ForecastPoint(
+        time=datetime.now(timezone.utc),
+        lat=24.3,
+        lon=54.4,
+        hs=1.234,
+        tp=9.876,
+        dp=200.0,
+        wind_speed=15.4321,
+        wind_dir=120.0,
+        swell_height=1.0,
+        swell_period=14.0,
+        swell_direction=220.0,
+    )
+    assessment = compute_risk(point)
+    for value in assessment.metrics.values():
+        before, _, after = value.partition(" ")
+        assert "." in before
+        whole, _, decimal = before.partition(".")
+        assert len(decimal) == 2
+        assert len(whole) >= 1
+        assert len(after) > 0
+
+
+def test_risk_assessment_serialization_round_trip() -> None:
+    now = datetime.now(timezone.utc)
+    point = ForecastPoint(
+        time=now,
+        lat=24.3,
+        lon=54.4,
+        hs=1.0,
+        tp=8.0,
+        dp=180.0,
+        wind_speed=12.0,
+        wind_dir=45.0,
+        swell_height=0.8,
+        swell_period=12.0,
+        swell_direction=200.0,
+    )
+    assessment = compute_risk(point)
+    serialized = assessment.model_dump()
+    restored = RiskAssessment.model_validate(serialized)
+    assert restored == assessment


### PR DESCRIPTION
## Summary
- add a Typer-based `wv` CLI with `check`, `schedule`, and `notify` commands backed by Stormglass, Open-Meteo, and NOAA data sources
- introduce disk-backed caching, risk evaluation utilities, voyage scheduling exports, and email/Slack/Telegram notification adapters
- document new workflows with an updated README, changelog, `.env.example`, lint settings, and end-to-end tests for providers, CLI, scheduler, and notifications

## Testing
- pytest -q
- black --check .
- isort --check-only .
- flake8 .
- mypy --strict src


------
https://chatgpt.com/codex/tasks/task_e_68d9af95b9c483279bc278e085af28eb